### PR TITLE
feat: 공통 레이아웃(Header, Mobile Nav) 구현 및 shadcn 컴포넌트 적용

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,12 +55,24 @@
 
   "overrides": [
     {
-      "files": ["*.test.js", "*.test.ts", "*.test.tsx", "*.stories.ts"],
+      "files": [
+        "*.test.ts",
+        "*.stories.ts",
+        // shadcn 컴포넌트 경로
+        "src/components/ui/**/*.tsx"
+      ],
       "rules": {
         // import/no-extraneous-dependencies 규칙
         // 프로덕션 코드에서 필요한 패키지는 dependencies에 있어야 한다고 강제함
         // 테스트 파일에 대해서는 no-extraneous-dependencies 규칙을 비활성화함
         "import/no-extraneous-dependencies": "off"
+      }
+    },
+    {
+      "files": ["src/components/ui/**/*.tsx"],
+      "rules": {
+        // shadcn 컴포넌트 파일에 대해서는 jsx-props-no-spreading 규칙 비활성화
+        "react/jsx-props-no-spreading": "off"
       }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-slot": "^1.1.0",
         "@tanstack/react-query": "^5.56.2",
         "@tanstack/react-query-devtools": "^5.56.2",
         "class-variance-authority": "^0.7.0",
@@ -3383,12 +3384,43 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-icons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.0.tgz",
       "integrity": "sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==",
       "peerDependencies": {
         "react": "^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rtsao/scc": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-slot": "^1.1.0",
     "@tanstack/react-query": "^5.56.2",
     "@tanstack/react-query-devtools": "^5.56.2",
     "class-variance-authority": "^0.7.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
+import { Header } from '@/components/Header';
+import { MobileNav } from '@/components/MobileNav';
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -28,7 +30,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
+        <MobileNav />
       </body>
     </html>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  BookHeadphones,
+  Search,
+  Trophy,
+  Bookmark,
+  Bell,
+  CircleUserRound,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export const navItems = [
+  { name: '학습', href: '/', icon: BookHeadphones },
+  { name: '챌린지', href: '/challenge', icon: Trophy },
+  { name: '검색', href: '/search', icon: Search },
+  { name: '스크랩', href: '/bookmark', icon: Bookmark },
+  { name: '관리', href: '/mypage', icon: CircleUserRound },
+];
+
+export function Header() {
+  const pathname = usePathname();
+
+  return (
+    <header className="bg-white shadow">
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between h-16">
+          <div className="flex items-center">
+            <Link href="/" className="text-xl font-bold">
+              English
+            </Link>
+            <nav className="hidden md:ml-6 md:flex md:space-x-4">
+              {navItems.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  className={`text-gray-700 hover:text-gray-900 ${
+                    pathname === item.href ? 'font-semibold' : ''
+                  }`}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <div className="flex items-center space-x-4">
+            <Button variant="ghost" size="icon">
+              <Bell className="h-5 w-5" />
+            </Button>
+            <Button variant="default" className="hidden md:inline-flex">
+              로그아웃
+            </Button>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { navItems } from './Header';
+
+export function MobileNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t">
+      <div className="flex justify-around">
+        {navItems.map((item) => (
+          <Link
+            key={item.name}
+            href={item.href}
+            className={`flex flex-col items-center py-2 ${
+              pathname === item.href ? 'text-blue-600' : 'text-gray-600'
+            }`}
+          >
+            <item.icon className="h-6 w-6" />
+            <span className="text-xs mt-1">{item.name}</span>
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };


### PR DESCRIPTION
### 📄 Description of the PR

- 공통 레이아웃(Header, Mobile Navigation)을 구현하고 shadcn 버튼 컴포넌트를 적용했습니다. 또한 ESLint 규칙을 수정하여 관련 경고를 해결했습니다.

---

### 🔧 What has been changed?

- 공통 레이아웃: Header와 Mobile Navigation 구현. 데스크탑에서는 헤더에 네비게이션, 모바일에서는 하단 네비게이션 표시
- shadcn 버튼 컴포넌트 적용: npx로 설치된 버튼 컴포넌트를 사용하여 UI 구성
- ESLint 규칙 추가: shadcn 컴포넌트에서 ...props 사용을 허용하기 위해 ESLint의 overrides에 규칙 추가

---

### 📸 Screenshots / GIFs (if applicable)

| 기능                                                        | 스크린샷    |
| ----------------------------------------------------------- | ----------- |
| ![GIF 설명](파일 경로)                                      | 설명 텍스트 |
| 추가된 화면 스크린샷이나, 동작을 설명할 GIF를 첨부해주세요. |

---

### ⚠️ Precaution & Known issues

- 아직 Header, MobileNav 컴포넌트를 Storybook으로 분리하지 않았습니다. 모든 페이지에서 사용되지만 Storybook으로 분리하는 게 의미가 있는지 확신이 서지 않아서 일단 분리하지 않았습니다. 그리고 Storybook 파일을 어디에 놓아야 할지 고민 중입니다.

Close #5 
