### PR TITLE
feat: /mypage 경로에 공통 레이아웃 적용

### DIFF
--- a/src/app/mypage/challenges/page.tsx
+++ b/src/app/mypage/challenges/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div className="">MyChallengesPage</div>;
+}

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+
+type Tab = 'profile' | 'learn' | 'challenges';
+
+const tabs: { key: Tab; label: string; href: string }[] = [
+  { key: 'profile', label: '프로필', href: '/mypage' },
+  { key: 'learn', label: '나의 학습', href: '/mypage/learn' },
+  { key: 'challenges', label: '나의 챌린지', href: '/mypage/challenges' },
+];
+
+export default function MyPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [activeTab, setActiveTab] = useState<Tab>('profile');
+
+  useEffect(() => {
+    if (pathname.startsWith('/mypage/learn')) setActiveTab('learn');
+    else if (pathname.startsWith('/mypage/challenges'))
+      setActiveTab('challenges');
+    else setActiveTab('profile');
+  }, [pathname]);
+
+  return (
+    <>
+      <nav className="bg-white border-b">
+        <ul className="flex justify-center items-center h-11">
+          {tabs.map(({ key, label, href }) => (
+            <li key={key} className="relative">
+              <Link
+                href={href}
+                className={`inline-block px-2 py-3 text-center font-medium transition-colors whitespace-nowrap ${
+                  activeTab === key && 'font-bold'
+                }`}
+              >
+                {label}
+              </Link>
+              {activeTab === key && (
+                <span className="absolute bottom-0 left-0 w-full h-[2px] bg-black" />
+              )}
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/src/app/mypage/learn/page.tsx
+++ b/src/app/mypage/learn/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div className="">MyLearnPage</div>;
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div className="">Profile</div>;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,48 +13,46 @@ import {
 import { Button } from '@/components/ui/button';
 
 export const navItems = [
-  { name: '학습', href: '/', icon: BookHeadphones },
-  { name: '챌린지', href: '/challenge', icon: Trophy },
+  { name: '학습', href: '/learn', icon: BookHeadphones },
+  { name: '챌린지', href: '/challenges', icon: Trophy },
   { name: '검색', href: '/search', icon: Search },
-  { name: '스크랩', href: '/bookmark', icon: Bookmark },
-  { name: '관리', href: '/mypage', icon: CircleUserRound },
+  { name: '스크랩', href: '/bookmarks', icon: Bookmark },
+  { name: '마이페이지', href: '/mypage', icon: CircleUserRound },
 ];
 
 export function Header() {
   const pathname = usePathname();
 
   return (
-    <header className="bg-white shadow">
-      <div className="container mx-auto px-4">
-        <div className="flex items-center justify-between h-16">
-          <div className="flex items-center">
-            <Link href="/" className="text-xl font-bold">
-              English
+    <div className="z-50 bg-white border-b">
+      <header className="flex items-center max-w-[1440px] h-16 px-6 mx-auto">
+        <Link href="/" className="text-xl font-bold mr-6">
+          English
+        </Link>
+        <nav className="hidden md:flex md:items-center">
+          {navItems.map((item) => (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={`py-3 px-6 text-lg flex-shrink-0 ${
+                pathname === item.href || pathname.startsWith(item.href)
+                  ? 'font-bold'
+                  : ''
+              }`}
+            >
+              {item.name}
             </Link>
-            <nav className="hidden md:ml-6 md:flex md:space-x-4">
-              {navItems.map((item) => (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className={`text-gray-700 hover:text-gray-900 ${
-                    pathname === item.href ? 'font-semibold' : ''
-                  }`}
-                >
-                  {item.name}
-                </Link>
-              ))}
-            </nav>
-          </div>
-          <div className="flex items-center space-x-4">
-            <Button variant="ghost" size="icon">
-              <Bell className="h-5 w-5" />
-            </Button>
-            <Button variant="default" className="hidden md:inline-flex">
-              로그아웃
-            </Button>
-          </div>
+          ))}
+        </nav>
+        <div className="flex items-center ml-auto">
+          <Button variant="ghost" size="icon">
+            <Bell className="h-5 w-5" />
+          </Button>
+          <Button variant="default" className="hidden md:inline-flex ml-4">
+            로그아웃
+          </Button>
         </div>
-      </div>
-    </header>
+      </header>
+    </div>
   );
 }


### PR DESCRIPTION
### 📄 Description of the PR

- /mypage로 시작하는 모든 경로에 공통 레이아웃을 적용하여, 동일한 탭 네비게이션을 보여주도록 했습니다.

---

### 🔧 What has been changed?

- 탭 네비게이션 구현 (/mypage, /mypage/learn, /mypage/challenges)
- 헤더 크기 조정 시 끊기는 현상 개선

---

### 📸 Screenshots / GIFs (if applicable)

| 기능                                                        | 스크린샷    |
| ----------------------------------------------------------- | ----------- |
| ![GIF 설명](파일 경로)                                      | 설명 텍스트 |
| 추가된 화면 스크린샷이나, 동작을 설명할 GIF를 첨부해주세요. |

---

### ⚠️ Precaution & Known issues

- 탭 네비게이션이 마이페이지, 스크랩, 학습 카테고리에서 내용만 다를 뿐 비슷한 UI라고 생각해서 재사용 가능한 컴포넌트로 분리하려고 합니다!
