### PR TITLE
feat : 컨텐츠 담는 Card 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "f2-english-fe",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-aspect-ratio": "^1.1.0",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@tanstack/react-query": "^5.56.2",
@@ -3384,6 +3385,29 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.0.tgz",
+      "integrity": "sha512-dP87DM/Y7jFlPgUZTlhx6FF5CEzOiaxp2rBCKlaXlpH5Ip/9Fg5zZ9lDOQ5o/MOfUlf36eak14zoWYpgcgGoOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
@@ -3404,6 +3428,29 @@
       "integrity": "sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==",
       "peerDependencies": {
         "react": "^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-slot": {
@@ -4646,7 +4693,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@radix-ui/react-aspect-ratio": "^1.1.0",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@tanstack/react-query": "^5.56.2",

--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -1,5 +1,5 @@
 import Cards from '@/components/Cards';
 
-export default function learnTestPage() {
+export default function learnPage() {
   return <Cards />;
 }

--- a/src/app/learn/test/page.tsx
+++ b/src/app/learn/test/page.tsx
@@ -1,0 +1,5 @@
+import Cards from '@/components/Cards';
+
+export default function learnTestPage() {
+  return <Cards />;
+}

--- a/src/components/Cards.tsx
+++ b/src/components/Cards.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Card, CardDescription, CardTitle } from '@/components/ui/card';
 import { AspectRatio } from '@/components/ui/aspect-ratio';
 import Image from 'next/image';
@@ -19,10 +17,6 @@ function Cards() {
                 alt={card.title}
                 className="rounded-md object-cover"
                 fill
-                // Add a placeholder or error handling for missing images
-                onError={() =>
-                  console.warn(`Failed to load image for ${card.title}`)
-                }
                 priority // Ensures fast loading for the first card
               />
             </AspectRatio>
@@ -31,7 +25,6 @@ function Cards() {
               {card.title}
             </CardTitle>
             {/* 2줄 이상 ...필요 */}
-            {/* <CardDescription>`조회수 ${card.content}회`</CardDescription> */}
             <CardDescription>{formatViewCount(card.count)}</CardDescription>
           </Card>
         ))}

--- a/src/components/Cards.tsx
+++ b/src/components/Cards.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Card, CardDescription, CardTitle } from '@/components/ui/card';
+import { AspectRatio } from '@/components/ui/aspect-ratio';
+import Image from 'next/image';
+import { formatViewCount } from '@/lib/utils';
+import cardData from '@/mock/cardData.json';
+import { Badge } from './ui/badge';
+
+function Cards() {
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m">
+        {cardData.map((card) => (
+          <Card className="p-4" key={card.id}>
+            <AspectRatio ratio={16 / 9}>
+              <Image
+                src={card.imageUrl}
+                alt={card.title}
+                className="rounded-md object-cover"
+                fill
+                // Add a placeholder or error handling for missing images
+                onError={() =>
+                  console.warn(`Failed to load image for ${card.title}`)
+                }
+                priority // Ensures fast loading for the first card
+              />
+            </AspectRatio>
+            <Badge className="m-4 ml-0 mb-0">{card.category}</Badge>
+            <CardTitle className="mt-4 p-0 truncate ...">
+              {card.title}
+            </CardTitle>
+            {/* 2줄 이상 ...필요 */}
+            {/* <CardDescription>`조회수 ${card.content}회`</CardDescription> */}
+            <CardDescription>{formatViewCount(card.count)}</CardDescription>
+          </Card>
+        ))}
+      </div>
+    </main>
+  );
+}
+
+export default Cards;

--- a/src/components/ui/aspect-ratio.tsx
+++ b/src/components/ui/aspect-ratio.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio';
+
+const AspectRatio = AspectRatioPrimitive.Root;
+
+export { AspectRatio };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, children, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-xl border bg-card text-card-foreground shadow',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+));
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex flex-col space-y-1.5 p-6', className)}
+    {...props}
+  />
+));
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn('font-semibold leading-none tracking-tight', className)}
+    {...props}
+  >
+    Your Heading Text Here
+  </h3>
+));
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center p-6 pt-0', className)}
+    {...props}
+  />
+));
+CardFooter.displayName = 'CardFooter';
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,32 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatViewCount(count: number) {
+  const billion = 100000000; // 억
+  const tenThousand = 10000; // 만
+  const thousand = 1000; // 천
+
+  const formatNumber = (num: number) => {
+    const fixedNum = num.toFixed(1);
+    return parseFloat(fixedNum) % 1 === 0 ? fixedNum.split('.')[0] : fixedNum;
+  };
+
+  if (count >= billion) {
+    const result = count / billion;
+    return `${formatNumber(result)}억회`;
+  }
+
+  if (count >= tenThousand) {
+    // 만 단위 이상은 만으로 표기
+    const result = Math.floor(count / tenThousand);
+    return `${formatNumber(result)}만회`;
+  }
+
+  if (count >= thousand) {
+    const result = count / thousand;
+    return `${formatNumber(result)}천회`;
+  }
+
+  return `${count}회`; // 천 미만일 경우 그대로 표시
+}

--- a/src/mock/cardData.json
+++ b/src/mock/cardData.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": 1,
+    "header": "Header 1",
+    "title": "컨텐츠 1",
+    "content": "Content for 컨텐츠 1",
+    "imageUrl": "/path-to-image1.jpg",
+    "category": "카테고리",
+    "count": 1002
+  },
+  {
+    "id": 2,
+    "header": "Header 2",
+    "title": "컨텐츠 2",
+    "content": "Content for 컨텐츠 2",
+    "imageUrl": "/path-to-image2.jpg",
+    "category": "카테고리",
+    "count": 1000002
+  },
+  {
+    "id": 3,
+    "header": "Header 3",
+    "title": "컨텐츠 3",
+    "content": "Content for 컨텐츠 3",
+    "imageUrl": "/path-to-image3.jpg",
+    "category": "카테고리",
+    "count": 25515240
+  },
+  {
+    "id": 4,
+    "header": "Header 4",
+    "title": "컨텐츠 4",
+    "content": "Content for 컨텐츠 4",
+    "imageUrl": "/path-to-image4.jpg",
+    "category": "카테고리",
+    "count": 100002
+  },
+  {
+    "id": 5,
+    "header": "Header 5",
+    "title": "컨텐츠 5",
+    "content": "Content for 컨텐츠 5",
+    "imageUrl": "/path-to-image5.jpg",
+    "category": "카테고리",
+    "count": 100002
+  },
+  {
+    "id": 6,
+    "header": "Header 6",
+    "title": "컨텐츠 6",
+    "content": "Content for 컨텐츠 6",
+    "imageUrl": "/path-to-image6.jpg",
+    "category": "카테고리",
+    "count": 100002
+  },
+  {
+    "id": 7,
+    "header": "Header 7",
+    "title": "컨텐츠 7",
+    "content": "Content for 컨텐츠 7",
+    "imageUrl": "/path-to-image7.jpg",
+    "category": "카테고리",
+    "count": 100002
+  },
+  {
+    "id": 8,
+    "header": "Header 8",
+    "title": "컨텐츠 8",
+    "content": "Content for 컨텐츠 8",
+    "imageUrl": "/path-to-image8.jpg",
+    "category": "카테고리",
+    "count": 100002
+  },
+  {
+    "id": 9,
+    "header": "Header 9",
+    "title": "컨텐츠 9",
+    "content": "Content for 컨텐츠 9",
+    "imageUrl": "/path-to-image9.jpg",
+    "category": "카테고리",
+    "count": 100002
+  },
+  {
+    "id": 10,
+    "header": "Header 10",
+    "title": "컨텐츠 10",
+    "content": "Content for 컨텐츠 10 Content for 컨텐츠 10 Content for 컨텐츠 10 Content for 컨텐츠 제목 10",
+    "imageUrl": "/path-to-image10.jpg",
+    "category": "카테고리",
+    "count": 100002
+  }
+]


### PR DESCRIPTION
### 📄 Description of the PR

- 컨텐츠 담는 Card 컴포넌트 구현

---

### 🔧 What has been changed?

- 컨텐츠를 담는 Card컴포넌트를 만들었습니다. 
-> app/test/page.tsx에서 직접 컴포넌트 ui 확인하실 수 있습니다. 

- 조회수 단위 계산해서 보여주는 formatViewCount유틸함수 구현


---

### 📸 Screenshots / GIFs (if applicable)
![image](https://github.com/user-attachments/assets/3e29c29c-6473-4fe0-ae4a-70c2806075b1)
Card 컴포넌트


---

### ⚠️ Precaution & Known issues

- 주의사항, 미처 구현하지 못한 부분, 해결되지 않은 문제가 있다면 작성해주세요.

- [ ]  전체 width에 적용되는 base container 설정 필요
- [ ] use clinet를 필수로 사용해야하는 onclick 대신 Link태그를 사용해서 컴포넌트 구현하는 법 고려 필요
- [ ] 2줄 ellipse설정 필요
- [ ] 주석 지우기
