### PR TITLE
feat: Storybook에 Input 컴포넌트 스토리 작성

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,4 @@
+import '../src/app/globals.css';
 import type { Preview } from '@storybook/react';
 
 const preview: Preview = {

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Input from './Input';
+
+const meta = {
+  title: 'Component/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['default', 'small', 'large'],
+    },
+    placeholder: { control: 'text' },
+    disabled: { control: 'boolean' },
+    error: { control: 'boolean' },
+    errorMessage: { control: 'text' },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter text...',
+    size: 'default',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    placeholder: 'Small input...',
+    size: 'small',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    placeholder: 'Large input...',
+    size: 'large',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Disabled input...',
+    disabled: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    placeholder: 'Input with error...',
+    error: true,
+    errorMessage: 'This field is required.',
+  },
+};

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Input as ShadcnInput } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  size?: 'default' | 'small' | 'large';
+  error?: boolean;
+  errorMessage?: string;
+}
+
+const sizeClasses = {
+  default: 'h-10 px-4 py-2 text-base',
+  small: 'h-8 px-3 py-1 text-sm',
+  large: 'h-12 px-5 py-3 text-lg',
+};
+
+function Input({
+  size = 'default',
+  error,
+  errorMessage,
+  className,
+  ...props
+}: InputProps) {
+  return (
+    <div className="flex flex-col space-y-1">
+      <ShadcnInput
+        className={cn(
+          'border rounded-md ',
+          sizeClasses[size],
+          error
+            ? 'border-red-500 focus:border-red-500 focus:ring-2 focus:ring-red-500 ring-red-500'
+            : 'border-gray-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 ring-blue-500',
+          className,
+        )}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+      />
+      {error && errorMessage && (
+        <p className="text-sm text-red-500 mt-1">{errorMessage}</p>
+      )}
+    </div>
+  );
+}
+
+export default Input;

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input };


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명: shadcn Input 컴포넌트를 기반으로 커스텀 Input을 구현하고 다양한 상태를 확인할 수 있도록 스토리를 추가했어요
- Close #13 

### 🔧 What has been changed?

- Storybook에서 Tailwind 스타일이 적용되도록 preview.ts에 globals.css 추가
- shadcn input 컴포넌트 추가
- 커스텀  Input 컴포넌트 구현, `size`, `error`, `errorMessage` 등의 속성 추가
- 여러 상태를 볼 수 있도록 Storybook 스토리 작성

### 📸 Screenshots / GIFs (if applicable)
![image](https://github.com/user-attachments/assets/e74e267a-1656-4438-81cc-5eb0ef8f881e)

### ⚠️ Precaution & Known issues
- input 이 focus 상태일 때 ring을 적용하고 싶은데 색상이 잘 적용이 안 되네요.
- components/Input/ 안에 Input.tsx, Input.stories.ts 구조로 story를 넣어두었어요
