### PR TITLE
feat : rewrites Rule을 이용하여 proxy 서버 세팅

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,14 @@ const nextConfig = {
   images: {
     domains: ['media.cnn.com'], // 외부 이미지 도메인 추가
   },
+  rewrites: async () => {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://13.238.253.88:8080/api/:path*',
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : nextjs로 proxy server setting을 했습니다.

- Close #26 

### 🔧 What has been changed?

프론트 서버(nextjs자체 서버)에 proxy서버로 만들어서 이제 프론트 로컬에서 스웨거 주소로 접근이 가능합니다.

프론트 <-> Proxy서버 <-> 백엔드

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
다만 , Oauth측면에서 naver로 로그인 성공후 proxy server에서 FE로 리다이렉트 되는 부분에서 이슈가 있습니다. 토큰 혹은 쿠키를 잘 담아오지 못하는 문제로 추정합니다. 백엔드의 oauth redirect url을 참고해서 비교해봐야할 듯 합니다. 

FE <-> proxy server<-> naver
