### PR TITLE
feat : 리딩 디테일 페이지 기본 레이아웃 구현, 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-aspect-ratio": "^1.1.0",
         "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@storybook/addon-actions": "^8.3.4",
         "@tanstack/react-query": "^5.56.2",
@@ -3437,6 +3438,29 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.0.tgz",
+      "integrity": "sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@radix-ui/react-aspect-ratio": "^1.1.0",
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@storybook/addon-actions": "^8.3.4",
     "@tanstack/react-query": "^5.56.2",

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -33,31 +33,23 @@ export default function DetailReadingPage({
           className="rounded-lg"
         />
       </div>
-      {/* 한글 있는 버전도 만들어 넣기 */}
-      <ul className="overflow-auto mb-8 w-[800px]  tracking-normal leading-loose">
-        {/* 5문장 기준으로 한 문단으로 묶어서 보여주기 */}
-        {Data.scripts.map((script, index) =>
-          // 한 문단의 첫 번째 문장에 indentation 주기
-          // eslint-disable-next-line no-nested-ternary
-          (index + 1) % 5 === 1 ? (
-            <li key={index} className="inline">
-              &nbsp;&nbsp;&nbsp;&nbsp;{script.enScript}
-            </li>
-          ) : // 한 문단의 마지막 문장에 줄바꿈 추가
-          (index + 1) % 5 === 0 ? (
-            <li key={index} className="inline">
+      <ul className="overflow-auto mb-8 w-[800px] tracking-normal leading-loose">
+        {/* 1문장씩 영/한 보여줌 */}
+        {Data.scripts.map((script, index) => (
+          <>
+            <li key={index} className="relative group">
               {script.enScript}
-
-              <br />
-              <br />
+              <div
+                key={index}
+                className="absolute opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100 bg-white rounded shadow-lg"
+              >
+                {script.koScript}
+              </div>
             </li>
-          ) : (
-            // 아무것도 적용되지 않는 문장
-            <li key={index} className="inline">
-              {script.enScript}
-            </li>
-          ),
-        )}
+            <br />
+            <br />
+          </>
+        ))}
       </ul>
       <div>플로팅 북마크 버튼</div>
       <div>플로팅 위로 올리기 버튼</div>

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -18,9 +18,9 @@ export default function DetailReadingPage({
 }: {
   params: { id: string };
 }) {
-  const [isButtonClicked, setButtonClicked] = useState(true);
+  const [isTranslateButtonClicked, setTranslateButtonClicked] = useState(true);
   const toggleTranslation = () => {
-    setButtonClicked(!isButtonClicked);
+    setTranslateButtonClicked(!isTranslateButtonClicked);
   };
 
   return (
@@ -52,7 +52,7 @@ export default function DetailReadingPage({
                 {script.enScript}
               </li>
               {/* 번역버튼 눌렸을때만 한글 자막 보여줌 */}
-              {isButtonClicked && (
+              {isTranslateButtonClicked && (
                 <li key={index} className="  bg-white rounded shadow-mille">
                   {script.koScript}
                 </li>
@@ -67,10 +67,10 @@ export default function DetailReadingPage({
           <Button
             onClick={toggleTranslation}
             variant="default"
-            className={`rounded-full p-3 shadow-lg ${isButtonClicked ? 'bg-blue-500 hover:bg-blue-500/90' : ''}`}
+            className={`rounded-full p-3 shadow-lg ${isTranslateButtonClicked ? 'bg-blue-500 hover:bg-blue-500/90' : ''}`}
           >
             <Languages className="w-5 h-5" />
-            {`번역${isButtonClicked ? 'ON' : 'OFF'}`}
+            {`번역${isTranslateButtonClicked ? 'ON' : 'OFF'}`}
           </Button>
         </div>
         <div className="fixed right-[16px] bottom-[76px] md:bottom-[16px]">

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -1,58 +1,89 @@
-// detailPage에서는 해당 페이지의 contentId로 데이터를 fetch하여 보여준다
-
+// todo : detailPage에서는 해당 페이지의 contentId로 데이터를 fetch하여 보여준다
 // const fetchDataByPageId = () => {
 //   Response.json();
 // };
+
+'use client';
 
 import Data from '@/mock/readingDetailData.json';
 import Image from 'next/image';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
+import { ArrowUp, Languages } from 'lucide-react';
+import { useState } from 'react';
 
 export default function DetailReadingPage({
   params,
 }: {
   params: { id: string };
 }) {
-  return (
-    <div className="flex flex-col items-center px-[10%]  md:mb-[1.5rem] max-w-[1024px] mb-[2.5rem]">
-      <div className="flex flex-col gap-2 my-3 justify-between items-start w-full">
-        <Badge>카테고리</Badge>
-        <div className="font-bold text-3xl  mt-2 mb-4">{Data.title}</div>
-        <div className="flex justify-end w-full">조회수</div>
-        {/* 받는 Data 이름이 thumbnail이면 안 됨  */}
-      </div>
+  const [isButtonClicked, setButtonClicked] = useState(true);
+  const toggleTranslation = () => {
+    setButtonClicked(!isButtonClicked);
+  };
 
-      <Separator className="" />
-      <div className="my-3">
-        <Image
-          src={Data.thumbnail}
-          width={600}
-          height={400}
-          alt="이미지"
-          className="rounded-lg"
-        />
-      </div>
-      <ul className="overflow-auto mb-8 w-[800px] tracking-normal leading-loose">
+  return (
+    <>
+      {/* MobileNav가 생겼을 때 일관성을 유지하기 위해 MobileNav 높이 60px만큼 pb-[60-px]설정 */}
+      <div className="flex flex-col items-center px-[10%] py-[10%] max-w-[1024px] pb-[60px] md:pb-[0px]">
+        <div className="flex flex-col gap-2 my-3 justify-between items-start w-full">
+          <Badge>카테고리</Badge>
+          <div className="font-bold text-3xl  mt-2 mb-4">{Data.title}</div>
+          <div className="flex justify-end w-full">조회수</div>
+        </div>
+
+        <Separator className="" />
+        <div className="my-3">
+          <Image
+            src={Data.thumbnail}
+            width={600}
+            height={400}
+            alt="이미지"
+            className="rounded-lg"
+          />
+        </div>
         {/* 1문장씩 영/한 보여줌 */}
-        {Data.scripts.map((script, index) => (
-          <>
-            <li key={index} className="relative group">
-              {script.enScript}
-              <div
-                key={index}
-                className="absolute opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100 bg-white rounded shadow-lg"
-              >
-                {script.koScript}
-              </div>
-            </li>
-            <br />
-            <br />
-          </>
-        ))}
-      </ul>
-      <div>플로팅 북마크 버튼</div>
-      <div>플로팅 위로 올리기 버튼</div>
-    </div>
+        <ul className="overflow-auto mb-8 w-[600px] tracking-normal leading-loose">
+          {Data.scripts.map((script, index) => (
+            <>
+              {/* eslint-disable-next-line react/no-array-index-key */}
+              <li key={index} className=" bg-white rounded shadow-mille">
+                {script.enScript}
+              </li>
+              {/* 번역버튼 눌렸을때만 한글 자막 보여줌 */}
+              {isButtonClicked && (
+                <li key={index} className="  bg-white rounded shadow-mille">
+                  {script.koScript}
+                </li>
+              )}
+              {/* 문장 사이 줄바꿈 */}
+              <br />
+            </>
+          ))}
+        </ul>
+
+        <div className="fixed right-[60px] bottom-[76px] md:bottom-[16px]">
+          <Button
+            onClick={toggleTranslation}
+            variant="default"
+            className={`rounded-full p-3 shadow-lg ${isButtonClicked ? 'bg-blue-500 hover:bg-blue-500/90' : ''}`}
+          >
+            <Languages className="w-5 h-5" />
+            {`번역${isButtonClicked ? 'ON' : 'OFF'}`}
+          </Button>
+        </div>
+        <div className="fixed right-[16px] bottom-[76px] md:bottom-[16px]">
+          <Button
+            variant="default"
+            className="rounded-full p-3 shadow-lg"
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          >
+            <ArrowUp className="w-5 h-5" />
+          </Button>
+          {/* todo : 북마크 버튼도 필요  */}
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -3,6 +3,11 @@
 //   Response.json();
 // };
 
+// todo
+// 1. script받아서 보여주는 부분 ui 디벨롭 필요
+// 2. script받아서 보여주는 부분 한 문장으로 할지, 문단으로 할지
+// 3. 한글 자막 보여줄 때 hover로 할지 그냥 button만 누르면 보이게 할지
+
 'use client';
 
 import Data from '@/mock/readingDetailData.json';

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -1,0 +1,66 @@
+// detailPage에서는 해당 페이지의 contentId로 데이터를 fetch하여 보여준다
+
+// const fetchDataByPageId = () => {
+//   Response.json();
+// };
+
+import Data from '@/mock/readingDetailData.json';
+import Image from 'next/image';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+
+export default function DetailReadingPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  return (
+    <div className="flex flex-col items-center px-[10%]  md:mb-[1.5rem] max-w-[1024px] mb-[2.5rem]">
+      <div className="flex flex-col gap-2 my-3 justify-between items-start w-full">
+        <Badge>카테고리</Badge>
+        <div className="font-bold text-3xl  mt-2 mb-4">{Data.title}</div>
+        <div className="flex justify-end w-full">조회수</div>
+        {/* 받는 Data 이름이 thumbnail이면 안 됨  */}
+      </div>
+
+      <Separator className="" />
+      <div className="my-3">
+        <Image
+          src={Data.thumbnail}
+          width={600}
+          height={400}
+          alt="이미지"
+          className="rounded-lg"
+        />
+      </div>
+      {/* 한글 있는 버전도 만들어 넣기 */}
+      <ul className="overflow-auto mb-8 w-[800px]  tracking-normal leading-loose">
+        {/* 5문장 기준으로 한 문단으로 묶어서 보여주기 */}
+        {Data.scripts.map((script, index) =>
+          // 한 문단의 첫 번째 문장에 indentation 주기
+          // eslint-disable-next-line no-nested-ternary
+          (index + 1) % 5 === 1 ? (
+            <li key={index} className="inline">
+              &nbsp;&nbsp;&nbsp;&nbsp;{script.enScript}
+            </li>
+          ) : // 한 문단의 마지막 문장에 줄바꿈 추가
+          (index + 1) % 5 === 0 ? (
+            <li key={index} className="inline">
+              {script.enScript}
+
+              <br />
+              <br />
+            </li>
+          ) : (
+            // 아무것도 적용되지 않는 문장
+            <li key={index} className="inline">
+              {script.enScript}
+            </li>
+          ),
+        )}
+      </ul>
+      <div>플로팅 북마크 버튼</div>
+      <div>플로팅 위로 올리기 버튼</div>
+    </div>
+  );
+}

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -21,9 +21,9 @@ export default function DetailReadingPage() {
   //   // params: { id: string };
   // },
 
-  const [isTranslateButtonClicked, setTranslateButtonClicked] = useState(true);
+  const [showTranslate, toggleShowTranlation] = useState(true);
   const toggleTranslation = () => {
-    setTranslateButtonClicked(!isTranslateButtonClicked);
+    toggleShowTranlation(!showTranslate);
   };
 
   return (
@@ -50,18 +50,12 @@ export default function DetailReadingPage() {
         <ul className="overflow-auto mb-8 w-[600px] tracking-normal leading-loose">
           {Data.scripts.map((script, index) => (
             <>
-              {/* Q. 아래 Lint에러에 해당하는 index로 배열 key를 사용하지 않는 방법 외에 무엇이 있을까요? */}
               {/* eslint-disable-next-line react/no-array-index-key */}
               <li key={index} className=" bg-white rounded shadow-mille">
-                {script.enScript}
+                <p>{script.enScript}</p>
+                {/* 번역버튼 눌렸을때만 한글 자막 보여줌 */}
+                {showTranslate && <p>{script.koScript}</p>}
               </li>
-              {/* 번역버튼 눌렸을때만 한글 자막 보여줌 */}
-              {isTranslateButtonClicked && (
-                // eslint-disable-next-line react/no-array-index-key
-                <li key={index} className="  bg-white rounded shadow-mille">
-                  {script.koScript}
-                </li>
-              )}
               {/* 문장 사이 줄바꿈 */}
               <br />
             </>
@@ -72,10 +66,10 @@ export default function DetailReadingPage() {
           <Button
             onClick={toggleTranslation}
             variant="default"
-            className={`rounded-full p-3 shadow-lg ${isTranslateButtonClicked ? 'bg-blue-500 hover:bg-blue-500/90' : ''}`}
+            className={`rounded-full p-3 shadow-lg ${showTranslate ? 'bg-blue-500 hover:bg-blue-500/90' : ''}`}
           >
             <Languages className="w-5 h-5" />
-            {`번역${isTranslateButtonClicked ? 'ON' : 'OFF'}`}
+            {`번역${showTranslate ? 'ON' : 'OFF'}`}
           </Button>
         </div>
         <div className="fixed right-[16px] bottom-[76px] md:bottom-[16px]">

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -13,11 +13,14 @@ import { Button } from '@/components/ui/button';
 import { ArrowUp, Languages } from 'lucide-react';
 import { useState } from 'react';
 
-export default function DetailReadingPage({
-  params,
-}: {
-  params: { id: string };
-}) {
+export default function DetailReadingPage() {
+  // {
+  //   // params,
+  //   // 이전 페이지에서 Link로 넘어온 params를 받아오는 부분인데 이 페이지에서 어떻게 사용해야 할지 모르겠음
+  // }: {
+  //   // params: { id: string };
+  // },
+
   const [isTranslateButtonClicked, setTranslateButtonClicked] = useState(true);
   const toggleTranslation = () => {
     setTranslateButtonClicked(!isTranslateButtonClicked);
@@ -47,12 +50,14 @@ export default function DetailReadingPage({
         <ul className="overflow-auto mb-8 w-[600px] tracking-normal leading-loose">
           {Data.scripts.map((script, index) => (
             <>
+              {/* Q. 아래 Lint에러에 해당하는 index로 배열 key를 사용하지 않는 방법 외에 무엇이 있을까요? */}
               {/* eslint-disable-next-line react/no-array-index-key */}
               <li key={index} className=" bg-white rounded shadow-mille">
                 {script.enScript}
               </li>
               {/* 번역버튼 눌렸을때만 한글 자막 보여줌 */}
               {isTranslateButtonClicked && (
+                // eslint-disable-next-line react/no-array-index-key
                 <li key={index} className="  bg-white rounded shadow-mille">
                   {script.koScript}
                 </li>

--- a/src/components/ReadingPreview.tsx
+++ b/src/components/ReadingPreview.tsx
@@ -18,7 +18,7 @@ export default function ReadingPreview({
 
   return (
     <Link
-      href={`/english/learn/reading/detail/${id}`}
+      href={`/learn/reading/detail/${id}`}
       className="block bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow duration-200"
     >
       <div className="flex justify-between items-center p-4">

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as React from 'react';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+
+import { cn } from '@/lib/utils';
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = 'horizontal', decorative = true, ...props },
+    ref,
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/src/mock/readingDetailData.json
+++ b/src/mock/readingDetailData.json
@@ -1,0 +1,185 @@
+{
+  "_id": {
+    "$oid": "66f9710cc6ca227e07a590e4"
+  },
+  "contentType": "reading",
+  "title": "Why Do Our Joints Crack?",
+  "thumbnail": "https://media.cnn.com/api/v1/images/stellar/prod/gettyimages-2173421446.jpg?c=16x9&q=h_720,w_1280,c_fill",
+  "scripts": [
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "When a few weeks passed and Nana Prempeh still hadn’t heard from the guy she met on vacation, she turned to her friends for advice.",
+      "koScript": "몇 주가 지나도 나나 프렘페가 휴가에서 만난 남자에게서 소식을 듣지 못하자, 그녀는 친구들에게 조언을 구했다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“At least half of them were like, ‘Don’t call him.",
+      "koScript": "“적어도 절반은 '그에게 연락하지 마."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "Don’t contact him.",
+      "koScript": "그에게 연락하지 마."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "It’s a holiday romance.",
+      "koScript": "그건 휴가 중의 로맨스일 뿐이야."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "It’s done.",
+      "koScript": "그건 끝났어."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "It’s finished,’ ” Nana tells CNN Travel today.",
+      "koScript": "끝났어,’라고 나나는 오늘 CNN 트래블에 말했다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "Nana respected this perspective – it was, she figured, the logical conclusion.",
+      "koScript": "나나는 이 관점을 존중했다 – 그것이 논리적인 결론이라고 생각했다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "She was in London.",
+      "koScript": "그녀는 런던에 있었다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "Edouard, her vacation romance, was in Spain.",
+      "koScript": "휴가 중의 로맨스였던 에두아르는 스페인에 있었다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "But Nana kept replaying their first date in her head – the deserted beach, swimming at dusk, kissing on the sand.",
+      "koScript": "하지만 나나는 그들의 첫 데이트를 머릿속에서 계속 재생했다 – 한적한 해변, 해질녘 수영, 모래 위에서의 키스."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“I couldn’t stop thinking about him,” she says.",
+      "koScript": "“그를 생각하지 않을 수 없었어요,” 그녀는 말한다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "A handful of her friends were more magnanimous, suggesting maybe Edouard was busy, perhaps she should wait and see if he called.",
+      "koScript": "소수의 친구들은 더 관대하게, 에두아르가 바빴을지 모르니 그가 연락할지 기다려 보라고 제안했다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "One friend’s advice stood out.",
+      "koScript": "한 친구의 조언이 특히 눈에 띄었다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“Stood out distinctly …” says Nana.",
+      "koScript": "“분명히 눈에 띄었어요 …” 나나는 말한다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“Because she had actually married a guy she’d met on holiday.",
+      "koScript": "“그녀는 실제로 휴가에서 만난 남자와 결혼했기 때문이었어요."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "And she said, ‘You should go for it.",
+      "koScript": "그리고 그녀는 '한번 해봐."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "What do you have to lose?’ ” Nana trusted this friend’s perspective – she knew what she was talking about.",
+      "koScript": "잃을 게 뭐가 있겠어?’라고 말했어요.” 나나는 이 친구의 관점을 신뢰했다 – 그녀는 자신이 무슨 말을 하는지 알고 있었다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "So one evening, Nana decided to dial Edouard’s number.",
+      "koScript": "그래서 어느 날 저녁, 나나는 에두아르의 번호를 돌리기로 결심했다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“I picked up the phone, and I called him,” says Nana.",
+      "koScript": "“나는 전화를 들고, 그에게 전화했어요,” 나나는 말한다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "Nana told herself it didn’t matter either way – she just wanted an answer, but whatever the outcome, she’d look back on her time with Edouard fondly.",
+      "koScript": "나나는 스스로에게 어느 쪽이든 상관없다고 말했어요 – 단지 답을 원했을 뿐이고, 어떤 결과가 나오든 에두아르와의 시간을 좋은 추억으로 남기겠다고요."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“I think he was surprised to hear from me, because I could just hear this silence at the end of the line when he picked up,” recalls Nana.",
+      "koScript": "“그가 내 전화를 받고 놀랐던 것 같아요, 왜냐하면 전화를 받았을 때 그저 침묵이 들렸거든요,” 나나는 회상한다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“I said, ‘Is that invitation to come back still open?’ And there was a long pause and he said, ‘Yes.’ ” Nana had flown to Ibiza in the summer of 2018 to celebrate her 39th birthday with a group of girlfriends.",
+      "koScript": "“나는 '돌아오라는 초대가 아직 유효해?'라고 물었어요. 그리고 긴 침묵 후에 그는 '그래'라고 대답했어요.” 나나는 2018년 여름, 그녀의 39번째 생일을 친구들과 함께 축하하기 위해 이비자에 날아갔다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "She saw the trip – and the birthday – as representing a new era.",
+      "koScript": "그녀는 그 여행과 생일을 새로운 시대의 시작으로 여겼다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "Nana had a busy job working as a lawyer in London.",
+      "koScript": "나나는 런던에서 변호사로 일하며 바쁜 나날을 보냈다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "In the past, she’d deprioritized her own well-being.",
+      "koScript": "과거에 그녀는 자신의 웰빙을 우선순위에서 제외시켰다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "But approaching her 40s, she was re-evaluating this approach.",
+      "koScript": "그러나 40대를 앞두고, 그녀는 이 방식을 재평가하고 있었다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "“I was like, ‘I want to put myself first.’ ” Nana hadn’t been on a proper vacation in a long time.",
+      "koScript": "“나는 '이제는 나를 우선시하자'라고 생각했어요.” 나나는 오랫동안 제대로 된 휴가를 가지지 못했다."
+    },
+    {
+      "startTimeInSecond": 0,
+      "durationInSecond": 0,
+      "enScript": "Her summer trip was partly about celebrating her birthday and partly about reclaiming her happiness.",
+      "koScript": "그녀의 여름 여행은 생일을 축하하는 것과 동시에 행복을 되찾기 위한 것이었다."
+    }
+  ],
+  "createdAt": {
+    "$date": "2024-09-29T15:23:56.384Z"
+  },
+  "updatedAt": {
+    "$date": "2024-09-29T15:23:56.384Z"
+  },
+  "_class": "com.echall.platform.content.domain.entity.ContentDocument"
+}


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 리딩 디테일 페이지 기본 레이아웃 구현

- Close #25 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- 리딩 디테일 페이지 기본 레이아웃 구현
- 누르면 한글 번역 나타나는 `번역버튼` 플로팅으로 구현 
- 누르면 화면 맨 위로 올라가는 `scroll top버튼` 플로팅으로 구현

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/89ad8bbd-f7b4-46a0-9da6-207f079b92e2)


### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
####
- 현재 ui에 대한 가감없는 피드백과 디벨롭 아이디어가 필요합니다...
#### 추후 구현 필요
- [ ] script받아서 보여주는 부분 ui 디벨롭 필요 
- [ ] script받아서 보여주는 부분 한 문장으로 할지, 문단으로 할지
- [ ] 한글 자막 보여줄 때 hover로 할지 그냥 button만 누르면 보이게 할지
등

### ✅ Checklist

- [x] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [x] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
