### PR TITLE
feat : 퀴즈 제출 시 자동으로 다음 퀴즈로 넘어가는 기능 추가 및 정답/오답 여부 표시 

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -6,7 +6,13 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface CarouselProps<T> {
   header?: ReactNode;
-  itemComponent: ({ data }: { data: T }) => JSX.Element;
+  itemComponent: ({
+    data,
+    onNext,
+  }: {
+    data: T;
+    onNext?: () => void;
+  }) => JSX.Element;
   previewDatas: T[]; // TODO(@smosco): data 타입 정의
   itemWidth?: number;
   itemsPerPage?: number;
@@ -62,8 +68,14 @@ export default function Carousel<T>({
         >
           {/* TODO(@smosco): 유니언 타입으로 인한 타입 단언 수정 */}
           {previewDatas.map((data, index) => {
-            // eslint-disable-next-line react/no-array-index-key
-            return <ItemComponent key={index} data={data} />;
+            return (
+              <ItemComponent
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                data={data}
+                onNext={nextSlide}
+              />
+            );
           })}
         </div>
 

--- a/src/components/quiz/Quiz.tsx
+++ b/src/components/quiz/Quiz.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { CircleCheck, CircleX } from 'lucide-react';
+import { shuffleArray } from '@/lib/utils';
 
 interface QuizData {
   id: number;
@@ -19,9 +20,7 @@ export default function Quiz({ data, onNext }: QuizProps) {
 
   useEffect(() => {
     setSelectedWords([]);
-    setRemainingWords(
-      data.answer.split(' ').sort(() => (Math.random() > 0.5 ? 1 : -1)),
-    );
+    setRemainingWords(shuffleArray(data.answer.split(' ')));
     setIsCorrect(null);
   }, [data]);
 

--- a/src/components/quiz/Quiz.tsx
+++ b/src/components/quiz/Quiz.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
+import { CircleCheck, CircleX } from 'lucide-react';
 
 interface QuizData {
   id: number;
@@ -9,15 +10,19 @@ interface QuizData {
 
 interface QuizProps {
   data: QuizData;
+  onNext?: () => void;
 }
-export default function Quiz({ data }: QuizProps) {
+export default function Quiz({ data, onNext }: QuizProps) {
   const [selectedWords, setSelectedWords] = useState<string[]>([]);
   const [remainingWords, setRemainingWords] = useState<string[]>([]);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
 
   useEffect(() => {
+    setSelectedWords([]);
     setRemainingWords(
       data.answer.split(' ').sort(() => (Math.random() > 0.5 ? 1 : -1)),
     );
+    setIsCorrect(null);
   }, [data]);
 
   const handleClickSelect = useCallback((word: string) => {
@@ -36,20 +41,20 @@ export default function Quiz({ data }: QuizProps) {
 
   const handleClickSubmit = useCallback(() => {
     const submittedAnswer = selectedWords.join(' ');
-    const isCorrect = submittedAnswer === data.answer;
-    if (isCorrect) {
-      console.log('정답입니다!');
-    } else {
-      console.log('오답입니다');
+    setIsCorrect(submittedAnswer === data.answer);
+
+    if (onNext) {
+      setTimeout(() => {
+        onNext();
+      }, 500);
     }
-    // TODO(@smosco): eslint 룰 체크
-    // react-hooks/exhaustive-deps
-  }, [selectedWords, data.answer]);
+  }, [selectedWords, data.answer, onNext]);
 
   return (
-    <div className="flex flex-col gap-2 w-full p-10 border">
+    <div className="flex flex-col gap-4 w-full p-10 border h-100">
       <p>{data.question}</p>
 
+      {/* 선택된 단어 표시 */}
       <div className="flex flex-wrap gap-2 border-b h-8">
         {selectedWords.map((word, index) => (
           <Button
@@ -64,6 +69,7 @@ export default function Quiz({ data }: QuizProps) {
         ))}
       </div>
 
+      {/* 남은 단어 표시 */}
       <div className="flex flex-wrap gap-2 h-8">
         {remainingWords.map((word, index) => (
           <Button
@@ -78,7 +84,32 @@ export default function Quiz({ data }: QuizProps) {
         ))}
       </div>
 
-      <Button onClick={handleClickSubmit}>제출</Button>
+      {/* 정답/오답 여부 표시 */}
+      <div className="flex h-12">
+        {isCorrect !== null && (
+          <div className={`${isCorrect !== null ? 'visible' : 'hidden'}`}>
+            {isCorrect ? (
+              <div className="flex">
+                <CircleCheck color="green" />
+                <p className="text-green-600 font-bold ml-1">정답입니다!</p>
+              </div>
+            ) : (
+              <div className="flex flex-col">
+                <div className="flex">
+                  <CircleX color="red" />
+                  <p className="text-red-600 font-bold ml-1">오답입니다</p>
+                </div>
+                <p className="text-red-600 font-bold">정답 : {data.answer}</p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 제출 버튼 */}
+      <Button className="mt-auto" onClick={handleClickSubmit}>
+        제출
+      </Button>
     </div>
   );
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,3 +33,13 @@ export function formatViewCount(count: number) {
 
   return `${count}회`; // 천 미만일 경우 그대로 표시
 }
+
+export const shuffleArray = <T>(array: T[]): T[] => {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled;
+};


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 퀴즈 제출 시 자동으로 다음 퀴즈로 넘어가는 기능을 추가하고 및 정답/오답 여부를 표시합니다.
- Close #44 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- 퀴즈 제출하면 정답/오답 여부 사용자에게 표시
- 0.5초 후에 자동으로 다음 퀴즈로 넘어감
  - itemComponent에 onNext 함수를 옵션으로 넘겨줌
- fisher-yates 셔플 알고리즘 사용해서 단어 랜덤하게 섞는 함수 구현

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/ac4357b8-9655-4fad-84e6-86713196ee28)
![image](https://github.com/user-attachments/assets/66460234-3305-4a06-84c6-4bced894777f)

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
- 퀴즈를 다 풀고 총 몇 개 맞았는지 보여주고 틀린 문제를 이어서 풀 수 있게 하는 기능 관련해서 아이디어를 주세요~

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
