### PR TITLE
feat : 라이브러리 레포의 demo폴더를 애플리케이션 videoPlayer폴더로 코드만 복사

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "next": "14.2.11",
         "react": "^18",
         "react-dom": "^18",
+        "react-player": "^2.16.0",
+        "sass": "^1.79.4",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.0-rc.2"
@@ -7320,7 +7322,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9726,6 +9727,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -10494,6 +10501,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
+      "license": "MIT"
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -10583,6 +10596,7 @@
       "version": "0.441.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.441.0.tgz",
       "integrity": "sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==",
+      "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
@@ -10677,6 +10691,12 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",
@@ -11954,7 +11974,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -12193,11 +12212,32 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-player": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.0.tgz",
+      "integrity": "sha512-mAIPHfioD7yxO0GNYVFD1303QFtI3lyyQZLY229UEAp/a10cSW+hPcakg0Keq8uWJxT2OiT/4Gt+Lc9bD6bJmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -12711,6 +12751,23 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sass": {
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
+      "integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/sass-loader": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
@@ -12747,6 +12804,34 @@
         "sass-embedded": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "next": "14.2.11",
     "react": "^18",
     "react-dom": "^18",
+    "react-player": "^2.16.0",
+    "sass": "^1.79.4",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^5.0.0-rc.2"

--- a/src/app/learn/listening/detail/[id]/page.tsx
+++ b/src/app/learn/listening/detail/[id]/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import VideoPlayer from '@/components/VideoPlayer';
+
+export default function DetailListeningPage() {
+  return (
+    <div className="flex">
+      <div className="flex flex-col flex-1 gap-5 mx-auto p-5 pb-16 max-w-[800px]">
+        <div>
+          <Badge>카테고리</Badge>
+          {/* <div className="font-bold text-2xl mt-2 mb-4">{Data.title}</div> */}
+          <div className="text-sm flex justify-end w-full">조회수</div>
+        </div>
+        <Separator />
+        <VideoPlayer />;
+      </div>
+    </div>
+  );
+}

--- a/src/app/learn/listening/page.tsx
+++ b/src/app/learn/listening/page.tsx
@@ -1,12 +1,16 @@
+'use Client';
+
 import listeningList from '@/mock/listeningList.json';
-import ContentsCard from '@/components/ContentsCard';
+// import ContentsCard from '@/components/ContentsCard';
+import ListeningPreviewCard from '@/components/ListeningPreviewCard';
 
 function listeningPage() {
   return (
     <main className="max-w-[1440px] mx-auto px-6 py-8">
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m">
         {listeningList.map((card) => (
-          <ContentsCard key={card.id} card={card} />
+          // <ContentsCard key={card.id} card={card} />
+          <ListeningPreviewCard key={card.id} data={card} />
         ))}
       </div>
     </main>

--- a/src/components/BookmarkSidebar.tsx
+++ b/src/components/BookmarkSidebar.tsx
@@ -23,9 +23,9 @@ export default function BookmarkSidebar({
     <>
       {/* 사이드바 */}
       <div
-        className={`fixed top-20 right-0 h-[30%] w-[30%] transform transition-transform duration-300 ease-in-out z-40 bg-gray-50 rounded-lg
+        className={`fixed top-20 right-0 h-[30%] w-[30%] transform transition-transform duration-300 ease-in-out z-40 bg-gray-50 bg-opacity-70 backdrop-blur-lg rounded-lg
       ${isSidebarOpen ? 'translate-x-0' : 'translate-x-full'}
-       xl:w-[300px] `}
+       xl:w-[300px] drop-shadow-xl `}
       >
         {/* todo : drag & drop으로 위치 변경 가능하게 만들기? or 배경화면 투명하게 */}
         {/* todo : 모바일 화면이면 30%민 보이도록 */}

--- a/src/components/VideoPlayer/ControlBar.tsx
+++ b/src/components/VideoPlayer/ControlBar.tsx
@@ -1,0 +1,137 @@
+/* eslint-disable react/self-closing-comp */
+/* eslint-disable jsx-a11y/interactive-supports-focus */
+import React, { RefObject, useState } from 'react';
+import ReactPlayer from 'react-player';
+import { Volume2, Play, Rewind, FastForward, Pause, Gauge } from 'lucide-react';
+import S from './VideoPlayer.module.scss';
+import formatTime from './utils/formatTime';
+
+interface BasicControlBarProps {
+  handlePlayPause: () => void;
+  handleSeekBackward: () => void;
+  handleSeekForward: () => void;
+  isPlaying: boolean;
+  handleVolumeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  volume: number;
+  setPlayBackRate: (rate: number) => void;
+}
+
+interface ControlBarProps {
+  playerRef: RefObject<ReactPlayer>;
+  BasicControlBarProps: BasicControlBarProps;
+}
+
+export default function ControlBar({
+  playerRef,
+  BasicControlBarProps,
+}: ControlBarProps) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const {
+    handlePlayPause,
+    isPlaying,
+    handleSeekBackward,
+    handleSeekForward,
+    handleVolumeChange,
+    volume,
+    setPlayBackRate,
+  } = BasicControlBarProps;
+
+  const handleMouseEvent = (
+    e: React.MouseEvent<HTMLDivElement>,
+    action: 'down' | 'up' | 'move',
+  ) => {
+    if (!playerRef.current || action === 'down') {
+      setIsDragging(true);
+    } else if (action === 'up') {
+      setIsDragging(false);
+      const progressBar = e.currentTarget;
+      const progressBarRect = progressBar.getBoundingClientRect();
+      const newTime =
+        ((e.clientX - progressBarRect.left) / progressBarRect.width) *
+        playerRef.current.getDuration();
+      playerRef.current.seekTo(newTime);
+    }
+  };
+  const [showPlaybackRate, setShowPlaybackRate] = useState(false);
+
+  const handleShowPlaybackRate = () => {
+    setShowPlaybackRate(!showPlaybackRate);
+  };
+
+  return (
+    <div className={S.controlBarWrapper}>
+      <div className={S.controlBar}>
+        <div className={S.leftControlBar}>
+          {/* 볼륨 슬라이더 */}
+          <div className={S.volumeSlideBar}>
+            <Volume2 fill="white" />
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={volume}
+              onChange={handleVolumeChange}
+              aria-label="Volume"
+            />
+          </div>
+          {/* 진행시간 박스 */}
+          <span className={S.timeViewBox}>
+            {`${formatTime(playerRef.current?.getCurrentTime() ?? 0)} / ${formatTime(playerRef.current?.getDuration() ?? 0)}`}
+          </span>
+        </div>
+        {/* 재생 조절 버튼 */}
+        <div className={S.centerControlBar}>
+          <Rewind fill="white" onClick={handleSeekBackward} />
+          {isPlaying ? (
+            <Pause fill="white" onClick={handlePlayPause} />
+          ) : (
+            <Play fill="white" onClick={handlePlayPause} />
+          )}
+          <FastForward fill="white" onClick={handleSeekForward} />
+        </div>
+
+        <div className={S.rightControlBar}>
+          {/* 배속조절버튼 */}
+          <Gauge onClick={handleShowPlaybackRate} />
+          {showPlaybackRate && (
+            <div className={S.playbackRateButton}>
+              {[0.5, 0.75, 1, 1.2, 1.5].map((rate) => (
+                // eslint-disable-next-line jsx-a11y/label-has-associated-control
+                <label key={rate} className={S.playbackRateLabel}>
+                  <input
+                    type="radio"
+                    name="playbackRate"
+                    value={rate}
+                    onClick={() => setPlayBackRate(rate)}
+                  />
+                  {rate}x
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* progressBar */}
+      <div
+        className={S.progressBar}
+        onMouseDown={(e) => handleMouseEvent(e, 'down')}
+        onMouseMove={(e) => isDragging && handleMouseEvent(e, 'move')}
+        onMouseUp={(e) => handleMouseEvent(e, 'up')}
+        onMouseLeave={() => setIsDragging(false)} // 드래그 상태 해제
+        role="progressbar"
+        aria-label="Progress"
+      >
+        <div
+          className={S.progressFill}
+          style={{
+            // eslint-disable-next-line no-unsafe-optional-chaining
+            width: `${playerRef.current?.getCurrentTime() && playerRef.current?.getDuration() ? (playerRef.current?.getCurrentTime() / playerRef.current.getDuration()) * 100 : 0}%`,
+          }}
+        ></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoPlayer/SubtitleOption.module.scss
+++ b/src/components/VideoPlayer/SubtitleOption.module.scss
@@ -1,0 +1,28 @@
+.optionContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .displayModeToggleContainer {
+    display: flex;
+    width: 12rem;
+    padding: 0.2rem;
+    background-color: #c7c7c7;
+    border-radius: 4px;
+
+    button {
+      width: 50%;
+      border: none;
+      cursor: pointer;
+      background: inherit;
+      padding: 0.5rem;
+      font-size: 0.8rem;
+      transition: background-color 0.3s ease-out;
+
+      &.active {
+        background-color: white;
+        border-radius: 4px;
+      }
+    }
+  }
+}

--- a/src/components/VideoPlayer/SubtitleOption.tsx
+++ b/src/components/VideoPlayer/SubtitleOption.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Dispatch, SetStateAction } from 'react';
+
+import styles from './SubtitleOption.module.scss';
+import { LanguageCode } from './core/interfaces/Scripts';
+
+type Mode = 'line' | 'block';
+
+interface SubtitleOptionProps {
+  mode: Mode;
+  availableLanguages: LanguageCode[]; // 전체 가능한 언어 옵션
+  selectedLanguages: LanguageCode[]; // 다중 선택 가능한 언어 배열
+  setSelectedLanguages: Dispatch<SetStateAction<LanguageCode[]>>;
+  setMode: Dispatch<SetStateAction<Mode>>;
+}
+
+export default function SubtitleOption({
+  mode,
+  availableLanguages,
+  selectedLanguages,
+  setSelectedLanguages,
+  setMode,
+}: SubtitleOptionProps) {
+  const handleLanguageChange = (language: LanguageCode) => {
+    if (selectedLanguages.includes(language)) {
+      setSelectedLanguages(
+        selectedLanguages.filter((lang) => lang !== language),
+      );
+    } else {
+      setSelectedLanguages([...selectedLanguages, language]);
+    }
+  };
+
+  return (
+    <div className={styles.optionContainer}>
+      {/* 모드 선택 버튼 */}
+      <div className={styles.displayModeToggleContainer}>
+        {['line', 'block'].map((item) => (
+          // eslint-disable-next-line react/button-has-type
+          <button
+            key={item}
+            className={`${mode === item ? styles.active : ''}`}
+            onClick={() => setMode(item as Mode)}
+          >
+            {item === 'line' ? '한 줄씩 보기' : '전체 보기'}
+          </button>
+        ))}
+      </div>
+
+      {/* 언어 선택 */}
+      <div className={styles.languageCheckboxContainer}>
+        {availableLanguages.map((item) => (
+          // eslint-disable-next-line jsx-a11y/label-has-associated-control
+          <label key={item} className={styles.languageOption}>
+            <input
+              type="checkbox"
+              value={item}
+              checked={selectedLanguages.includes(item)}
+              onChange={() => handleLanguageChange(item)}
+            />
+            {item}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoPlayer/VideoPlayer.module.scss
+++ b/src/components/VideoPlayer/VideoPlayer.module.scss
@@ -1,0 +1,131 @@
+.video {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: 640px;
+  border-radius: 20px; /* 바깥쪽 모서리 둥글게 */
+  overflow: hidden; /* 자식 요소가 부모 크기를 넘지 않도록 설정 */
+  & iframe {
+    width: 100%;
+    height: 100%;
+    clip-path: inset(0 round 20px); /* 안쪽 모서리 둥글게 */
+  }
+}
+.controlBarWrapper {
+  position: absolute;
+  width: 100%;
+  bottom: -5px;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 0.9) 100%
+  );
+}
+
+.controlBar {
+  width: 100%;
+  height: 50px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 30px;
+  color: white;
+  box-sizing: border-box;
+}
+.leftControlBar {
+  display: flex;
+  flex-direction: row;
+  @media (max-width: 500px) {
+    // 화면 크기가 500px 이하일 때 볼륨, 시간 버튼 숨김
+    display: none;
+  }
+}
+.centerControlBar {
+  position: absolute;
+  right: 50%;
+  transform: translateX(50%);
+  display: flex;
+  gap: 10px;
+  flex-direction: row;
+  cursor: pointer;
+}
+.rightControlBar {
+  display: flex;
+  flex-direction: row;
+}
+
+.volumeSlideBar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-right: 10px;
+
+  input[type='range'] {
+    width: 60px;
+    height: 5px;
+    border-radius: 15px;
+    cursor: pointer;
+    accent-color: white; // 볼륨 조절기 색상
+  }
+}
+
+.timeViewBox {
+  display: flex;
+  background-color: transparent;
+  align-items: center;
+  border: none;
+  color: white;
+  font-size: 0.8rem;
+}
+
+.progressBar {
+  position: relative;
+  width: 100%;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.3); /* 기본 채우기 색상 */
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.progressFill {
+  height: 100%;
+  background-color: rgb(
+    186,
+    133,
+    186
+  ); /* 진행된 부분의 색상, 반투명하게 설정 */
+  border-radius: 5px 0 0 5px;
+  transition: width 0.25s ease;
+}
+
+.rightControlBar {
+  display: flex;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+}
+
+.playbackRateButton {
+  position: absolute;
+  bottom: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  border-radius: 4px;
+}
+.playbackRateLabel {
+  display: block;
+  padding: 8px 12px;
+  font-size: 14px;
+  color: #ffffff;
+  cursor: pointer;
+  border-radius: inherit;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+  &:hover {
+    background-color: #000000;
+  }
+  input {
+    display: none;
+  }
+}

--- a/src/components/VideoPlayer/core/ReactScriptPlayer/BlockView.tsx
+++ b/src/components/VideoPlayer/core/ReactScriptPlayer/BlockView.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable react/button-has-type */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import React, { useRef, useEffect } from 'react';
+import { LanguageCode, Subtitle } from '../interfaces/Scripts';
+import styles from './ReactScriptPlayer.module.scss';
+import { convertTime } from '../utils/convertTime';
+import { TextDisplay } from './TextDisplay';
+
+interface BlockViewProps {
+  subtitles: Subtitle[];
+  currentSubtitleIndex: number;
+  selectedLanguages: LanguageCode[]; // 선택된 언어 배열
+  seekTo: (timeInSeconds: number) => void;
+  onClickSubtitle: (subtitle: Subtitle, index: number) => void;
+  onSelectWord: (word: string, subtitle: Subtitle, index: number) => void;
+}
+
+export function BlockView({
+  subtitles,
+  currentSubtitleIndex,
+  selectedLanguages,
+  seekTo,
+  onClickSubtitle,
+  onSelectWord,
+}: BlockViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      // console.log(containerRef.current);
+      if (currentSubtitleIndex < containerRef.current.children.length - 1) {
+        containerRef.current.children[currentSubtitleIndex].scrollIntoView({
+          block: 'center',
+          behavior: 'smooth',
+        });
+      }
+    }
+  }, [currentSubtitleIndex]);
+
+  return (
+    <div ref={containerRef} className={styles.blockViewContainer}>
+      {subtitles.map((subtitle, index) => (
+        <div
+          className={`${styles.subtitleItem} ${index === currentSubtitleIndex ? styles.active : ''}`}
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          onClick={() => {
+            // TODO(@smosco): 자막 클릭 함수 구현
+            seekTo(subtitle.startTimeInSecond);
+            onClickSubtitle(subtitle, index);
+          }}
+        >
+          <button>{convertTime(subtitle.startTimeInSecond)}</button>
+
+          <TextDisplay
+            subtitle={subtitles[index]}
+            selectedLanguages={selectedLanguages}
+            onSelectWord={onSelectWord}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/VideoPlayer/core/ReactScriptPlayer/Button.tsx
+++ b/src/components/VideoPlayer/core/ReactScriptPlayer/Button.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface ButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+export function Button({ label, onClick }: ButtonProps) {
+  // eslint-disable-next-line react/button-has-type
+  return <button onClick={onClick}>{label}</button>;
+}

--- a/src/components/VideoPlayer/core/ReactScriptPlayer/LineView.tsx
+++ b/src/components/VideoPlayer/core/ReactScriptPlayer/LineView.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable react/button-has-type */
 import React from 'react';
-import Image from 'next/image';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { LanguageCode, Subtitle } from '../interfaces/Scripts';
 // import { useState } from 'react';
-import arrow_back from '../assets/icons/arrow_back.svg';
-import arrow_forward from '../assets/icons/arrow_forward.svg';
 import { TextDisplay } from './TextDisplay';
 import styles from './ReactScriptPlayer.module.scss';
 
@@ -44,10 +42,10 @@ export function LineView({
     <div className={styles.lineViewContainer}>
       <div className={styles.skipButtonContainer}>
         <button onClick={handlePrevious}>
-          <Image src={arrow_back} alt="Back Arrow" />
+          <ChevronLeft />
         </button>
         <button onClick={handleNext}>
-          <Image src={arrow_forward} alt="Forward Arrow" />
+          <ChevronRight />
         </button>
       </div>
 

--- a/src/components/VideoPlayer/core/ReactScriptPlayer/LineView.tsx
+++ b/src/components/VideoPlayer/core/ReactScriptPlayer/LineView.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable react/button-has-type */
+import React from 'react';
+import Image from 'next/image';
+import { LanguageCode, Subtitle } from '../interfaces/Scripts';
+// import { useState } from 'react';
+import arrow_back from '../assets/icons/arrow_back.svg';
+import arrow_forward from '../assets/icons/arrow_forward.svg';
+import { TextDisplay } from './TextDisplay';
+import styles from './ReactScriptPlayer.module.scss';
+
+interface LineViewProps {
+  subtitles: Subtitle[];
+  selectedLanguages: LanguageCode[];
+  currentSubtitleIndex: number;
+  seekTo: (timeInSeconds: number) => void;
+  onSelectWord: (word: string, subtitle: Subtitle, index: number) => void;
+}
+
+export function LineView({
+  subtitles,
+  selectedLanguages,
+  currentSubtitleIndex,
+  seekTo,
+  onSelectWord,
+}: LineViewProps) {
+  // const [currentSubtitleIndex, setCurrentSubtitleIndex] = useState(0);
+  const totalSubtitles = subtitles.length;
+
+  const handlePrevious = () => {
+    if (currentSubtitleIndex > 0) {
+      seekTo(subtitles[currentSubtitleIndex - 1].startTimeInSecond);
+      // setCurrentSubtitleIndex((prev) => prev - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentSubtitleIndex < totalSubtitles - 1) {
+      seekTo(subtitles[currentSubtitleIndex + 1].startTimeInSecond);
+      // setCurrentSubtitleIndex((prev) => prev + 1);
+    }
+  };
+
+  return (
+    <div className={styles.lineViewContainer}>
+      <div className={styles.skipButtonContainer}>
+        <button onClick={handlePrevious}>
+          <Image src={arrow_back} alt="Back Arrow" />
+        </button>
+        <button onClick={handleNext}>
+          <Image src={arrow_forward} alt="Forward Arrow" />
+        </button>
+      </div>
+
+      {/* TextDisplay에서 현재 자막과 선택된 언어를 표시 */}
+      {subtitles[currentSubtitleIndex] && (
+        // TODO(@smosco):사용자가 자막이 언제 넘어갈지 알 수 있도록 progressbar 추가
+        <TextDisplay
+          subtitle={subtitles[currentSubtitleIndex]}
+          selectedLanguages={selectedLanguages}
+          onSelectWord={onSelectWord}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/VideoPlayer/core/ReactScriptPlayer/ReactScriptPlayer.module.scss
+++ b/src/components/VideoPlayer/core/ReactScriptPlayer/ReactScriptPlayer.module.scss
@@ -1,0 +1,53 @@
+.subtitleContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 90%;
+  max-width: 590px;
+  height: 16rem;
+  padding: 1.5rem;
+  border: 2px solid #e3e3e3;
+  border-radius: 0.5rem;
+  overflow-y: auto;
+}
+
+.lineViewContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  .skipButtonContainer {
+    align-self: end;
+
+    button {
+      cursor: pointer;
+    }
+  }
+}
+
+.blockViewContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  .subtitleItem {
+    padding: 16px;
+    border-radius: 12px;
+    transition: background-color 0.5s ease-in-out;
+
+    &.active {
+      background-color: lightgray;
+    }
+  }
+
+  button {
+    width: 5rem;
+    padding: 8px 12px;
+    border: none;
+    border-radius: 5rem;
+    background-color: #ececec;
+    cursor: pointer;
+    font-size: 0.8rem;
+    color: #5a5a5a;
+  }
+}

--- a/src/components/VideoPlayer/core/ReactScriptPlayer/TextDisplay.tsx
+++ b/src/components/VideoPlayer/core/ReactScriptPlayer/TextDisplay.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+import React from 'react';
+import { Subtitle, LanguageCode } from '../interfaces/Scripts';
+import styles from './ReactScriptPlayer.module.scss';
+
+export function TextDisplay({
+  subtitle,
+  selectedLanguages,
+  onSelectWord,
+}: {
+  subtitle: Subtitle;
+  selectedLanguages: LanguageCode[]; // 선택된 언어 배열
+  onSelectWord: (word: string, subtitle: Subtitle, index: number) => void;
+}) {
+  return (
+    <div className={styles.textView}>
+      {selectedLanguages.map((language) => (
+        <p
+          key={language}
+          className={styles[`text${language.toUpperCase()}`]}
+          onMouseUp={() => {
+            const selection = window.getSelection();
+            if (selection && selection.toString()) {
+              const selectedWord = selection.toString().trim();
+              if (selectedWord) {
+                // TODO(@smosco): 문장의 index, 문장 내 단어의 index까지 넘겨야할지 고민
+                onSelectWord(selectedWord, subtitle, 0);
+              }
+            }
+          }}
+        >
+          {subtitle[language] || `(${language} 자막이 없어요!)`}
+          {/* 선택된 언어가 없을 경우 대비 */}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/src/components/VideoPlayer/core/ReactScriptPlayer/index.tsx
+++ b/src/components/VideoPlayer/core/ReactScriptPlayer/index.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import styles from './ReactScriptPlayer.module.scss';
+import { LanguageCode, Subtitle } from '../interfaces/Scripts';
+import { LineView } from './LineView';
+import { BlockView } from './BlockView';
+
+export interface ReactScriptPlayerProps {
+  mode: 'line' | 'block';
+  subtitles: Subtitle[];
+  selectedLanguages: LanguageCode[];
+  seekTo: (timeInSeconds: number) => void;
+  currentTime: number;
+  onClickSubtitle: (subtitle: Subtitle, index: number) => void;
+  onSelectWord: (word: string, subtitle: Subtitle, index: number) => void;
+}
+
+export function ReactScriptPlayer({
+  mode,
+  subtitles,
+  selectedLanguages,
+  seekTo,
+  currentTime,
+  onClickSubtitle,
+  onSelectWord,
+}: ReactScriptPlayerProps) {
+  const reversedSubtitles = useMemo(
+    () => [...subtitles].reverse(),
+    [subtitles],
+  );
+  // TODO(@smosco): 현재 자막 인덱스 찾는 로직 리팩토링
+  const currentSubtitleIndex = useMemo(() => {
+    const index = reversedSubtitles.findIndex(
+      (subtitle) => subtitle.startTimeInSecond < currentTime,
+    );
+    return reversedSubtitles.length - 1 - index;
+  }, [reversedSubtitles, currentTime]);
+
+  return (
+    <div className={styles.subtitleContainer}>
+      <div className={styles.displayContainer}>
+        {/* TODO(@smosco): line, block 뷰 props가 거의 동일하기 때문에 공통 props로 추출해서 관리 */}
+        {mode === 'line' && (
+          <LineView
+            subtitles={subtitles}
+            currentSubtitleIndex={currentSubtitleIndex}
+            selectedLanguages={selectedLanguages}
+            seekTo={seekTo}
+            onSelectWord={onSelectWord}
+          />
+        )}
+        {mode === 'block' && (
+          <BlockView
+            subtitles={subtitles}
+            currentSubtitleIndex={currentSubtitleIndex}
+            selectedLanguages={selectedLanguages}
+            seekTo={seekTo}
+            onClickSubtitle={onClickSubtitle}
+            onSelectWord={onSelectWord}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoPlayer/core/assets/icons/arrow_back.svg
+++ b/src/components/VideoPlayer/core/assets/icons/arrow_back.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_17_4620)">
+<path d="M17.5098 3.86998L15.7298 2.09998L5.83984 12L15.7398 21.9L17.5098 20.13L9.37984 12L17.5098 3.86998Z" fill="#707070"/>
+</g>
+<defs>
+<clipPath id="clip0_17_4620">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/VideoPlayer/core/assets/icons/arrow_forward.svg
+++ b/src/components/VideoPlayer/core/assets/icons/arrow_forward.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_17_4639)">
+<path d="M6.49023 20.13L8.26023 21.9L18.1602 12L8.26023 2.09998L6.49023 3.86998L14.6202 12L6.49023 20.13Z" fill="#707070"/>
+</g>
+<defs>
+<clipPath id="clip0_17_4639">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/VideoPlayer/core/interfaces/Scripts.ts
+++ b/src/components/VideoPlayer/core/interfaces/Scripts.ts
@@ -1,0 +1,9 @@
+type LanguageCode = 'en' | 'ko' | 'ja' | 'de' | 'fr' | 'es';
+
+interface Subtitle extends Partial<Record<LanguageCode, string>> {
+  startTimeInSecond: number;
+  durationInSecond: number;
+  highlightedText?: string;
+}
+
+export type { LanguageCode, Subtitle };

--- a/src/components/VideoPlayer/core/utils/convertTime.ts
+++ b/src/components/VideoPlayer/core/utils/convertTime.ts
@@ -1,0 +1,11 @@
+export function convertTime(seconds: number) {
+  // 분과 초로 나눔
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.floor(seconds % 60);
+
+  // 두 자릿수로 맞추기
+  const paddedMinutes = String(minutes).padStart(2, '0');
+  const paddedSeconds = String(remainingSeconds).padStart(2, '0');
+
+  return `${paddedMinutes}:${paddedSeconds}`;
+}

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import ReactPlayer from 'react-player';
+import { ReactScriptPlayer } from './core/ReactScriptPlayer';
+import SubtitleOption from './SubtitleOption';
+import { LanguageCode } from './core/interfaces/Scripts';
+import scriptsMockData from './mocks/subtitleMockData';
+import { mockUrl } from './mocks/mockUrl';
+import ControlBar from './ControlBar';
+import Style from './VideoPlayer.module.scss';
+
+type Mode = 'line' | 'block';
+
+function VideoPlayer() {
+  const playerRef = useRef<ReactPlayer | null>(null);
+
+  const [mode, setMode] = useState<Mode>('line');
+
+  const availableLanguages: LanguageCode[] = ['en', 'ko', 'fr'];
+
+  const [selectedLanguages, setSelectedLanguages] =
+    useState<LanguageCode[]>(availableLanguages);
+  // 쓸모없다고 생각한 reactPlayer의 onProgress 구문을 삭제하면 controlbar의 progressbar업데이트가 느려지는 문제 발생.따라서 onProgress에 쓰이는 currentTime을 삭제하지 않음
+  const [currentTime, setCurrentTime] = useState(0);
+
+  const seekTo = (timeInSeconds: number) => {
+    if (playerRef.current) {
+      playerRef.current.seekTo(timeInSeconds, 'seconds');
+    }
+  };
+
+  // --- todo : ControlBar에서만 쓰이는 속성 ControlBar로 내부로 이동
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [volume, setVolume] = useState(0.5);
+  const [playbackRate, setPlayBackRate] = useState(1);
+  const handlePlayPause = () => {
+    setIsPlaying((prev) => !prev);
+  };
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newVolume = parseFloat(e.target.value);
+    setVolume(newVolume);
+  };
+
+  const handleSeek = (seconds: number) => {
+    if (playerRef.current) {
+      playerRef.current.seekTo(
+        (playerRef.current.getCurrentTime() || 0) + seconds,
+        'seconds',
+      );
+    }
+  };
+
+  const BasicControlBarProps = {
+    handlePlayPause,
+    handleVolumeChange,
+    handleSeekForward: () => handleSeek(10),
+    handleSeekBackward: () => handleSeek(-10),
+    isPlaying,
+    volume,
+    setPlayBackRate,
+  };
+  // ---
+
+  return (
+    <>
+      <div className={Style.video}>
+        <ReactPlayer
+          ref={playerRef}
+          url={mockUrl}
+          playing={isPlaying}
+          width="100%"
+          onPlay={() => setIsPlaying(true)}
+          onStart={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onProgress={({ playedSeconds }) => setCurrentTime(playedSeconds)} // 쓸모없다고 생각한 이 onProgress 구문을 삭제하면 controlbar의 progressbar업데이트가 느려지는 문제 발생.따라서 안 지움.
+          volume={volume}
+          controls={false} // 유튜브 자체 컨트롤러 안 뜨게
+          playbackRate={playbackRate}
+          progressInterval={100} // 기존 progress 업데이트 1초에서 0.1초로 변경 -> controlBar 클릭반응 느린문제 개선
+        />
+        <ControlBar
+          playerRef={playerRef}
+          BasicControlBarProps={BasicControlBarProps}
+        />
+      </div>
+      {/* 아래 부분은 npm배포 후 가져와야함 */}
+      <SubtitleOption
+        mode={mode}
+        selectedLanguages={selectedLanguages}
+        setMode={setMode}
+        setSelectedLanguages={setSelectedLanguages}
+        availableLanguages={availableLanguages}
+      />
+
+      <ReactScriptPlayer
+        mode={mode}
+        subtitles={scriptsMockData}
+        selectedLanguages={selectedLanguages}
+        seekTo={seekTo}
+        currentTime={currentTime}
+        onClickSubtitle={(subtitle, index) => {
+          console.log(subtitle, index);
+        }}
+        onSelectWord={(word, subtitle, index) => {
+          console.log(word, subtitle, index);
+        }}
+      />
+    </>
+  );
+}
+
+export default VideoPlayer;

--- a/src/components/VideoPlayer/mocks/mockUrl.ts
+++ b/src/components/VideoPlayer/mocks/mockUrl.ts
@@ -1,0 +1,1 @@
+export const mockUrl = 'https://www.youtube.com/watch?v=eIho2S0ZahI';

--- a/src/components/VideoPlayer/mocks/subtitleMockData.ts
+++ b/src/components/VideoPlayer/mocks/subtitleMockData.ts
@@ -1,0 +1,111 @@
+import { Subtitle } from '../core/interfaces/Scripts';
+
+const subtitles: Subtitle[] = [
+  {
+    startTimeInSecond: 0,
+    durationInSecond: 2,
+    ko: '시작해보죠',
+    en: "Let's get started",
+    fr: 'Commençons',
+  },
+  {
+    startTimeInSecond: 2.5,
+    durationInSecond: 4,
+    ko: '왜 그럴까요?',
+    en: 'And why is that?',
+    fr: 'Et pourquoi est-ce ainsi ?',
+  },
+  {
+    startTimeInSecond: 7,
+    durationInSecond: 5,
+    ko: '어떻게 하면 우리가 세상에 변화를 일으킬 수 있는 강력한 말을 할 수 있을까요?',
+    en: 'How can we speak powerfully to make change in the world?',
+    fr: 'Comment pouvons-nous parler avec force pour changer le monde ?',
+  },
+  {
+    startTimeInSecond: 12.5,
+    durationInSecond: 5,
+    ko: '제가 제안하고 싶은 것은 우리가 피해야 할 몇 가지 습관들이 있다는 것입니다.',
+    en: "What I'd like to suggest, there are a number of habits that we need to move away from.",
+    fr: "Ce que j'aimerais suggérer, c'est qu'il y a plusieurs habitudes dont nous devons nous éloigner.",
+  },
+  {
+    startTimeInSecond: 18,
+    durationInSecond: 6,
+    ko: '여기 말하는 것에 대한 7가지 치명적인 죄목을 여러분을 위해 모아봤습니다.',
+    en: "I've assembled for your pleasure here seven deadly sins of speaking.",
+    fr: "J'ai rassemblé pour vous sept péchés capitaux de la parole.",
+  },
+  {
+    startTimeInSecond: 24.5,
+    durationInSecond: 6,
+    ko: '이게 모든 것을 포함한 리스트는 아니지만, 이 7가지는 우리가 빠지기 쉬운 꽤 큰 습관들입니다.',
+    en: "I'm not pretending this is an exhaustive list, but these seven, I think, are pretty large habits that we can all fall into.",
+    fr: 'Je ne prétends pas que cette liste est exhaustive, mais ces sept points représentent de mauvaises habitudes dans lesquelles nous pouvons tous tomber.',
+  },
+  {
+    startTimeInSecond: 31,
+    durationInSecond: 3,
+    ko: '첫 번째, 험담.',
+    en: 'First, gossip.',
+    fr: 'Premièrement, les commérages.',
+  },
+  {
+    startTimeInSecond: 34.5,
+    durationInSecond: 4,
+    ko: '없는 사람에 대해 나쁘게 말하는 것.',
+    en: "Speaking ill of somebody who's not present.",
+    fr: "Parler en mal de quelqu'un qui n'est pas là.",
+  },
+  {
+    startTimeInSecond: 39,
+    durationInSecond: 8,
+    ko: '좋은 습관이 아니죠. 험담하는 사람이 5분 뒤에 우리에 대해서도 험담할 것을 우리는 잘 알고 있습니다.',
+    en: 'Not a nice habit, and we know perfectly well the person gossiping, five minutes later, will be gossiping about us.',
+    fr: "Ce n'est pas une bonne habitude, et nous savons très bien que la personne qui colporte des ragots, cinq minutes plus tard, fera de même à notre sujet.",
+  },
+  {
+    startTimeInSecond: 47.5,
+    durationInSecond: 4,
+    ko: '두 번째, 판단.',
+    en: 'Second, judging.',
+    fr: 'Deuxièmement, le jugement.',
+  },
+  {
+    startTimeInSecond: 52,
+    durationInSecond: 10,
+    ko: '대화를 나눌 때 이런 사람들을 알고 있죠. 만약 당신이 판단받고 있다는 사실을 안다면 상대방의 말을 듣기 어려울 것입니다.',
+    en: "We know people who are like this in conversation, and it's very hard to listen to somebody if you know that you're being judged and found wanting at the same time.",
+    fr: "Nous connaissons des personnes comme ça dans les conversations, et il est très difficile d'écouter quelqu'un si vous savez que vous êtes jugé et considéré comme insuffisant en même temps.",
+  },
+  {
+    startTimeInSecond: 63.5,
+    durationInSecond: 6,
+    ko: '세 번째, 부정적 언어. 우리는 부정적인 말보다는 긍정적인 말을 하는 습관을 들여야 합니다.',
+    en: 'Third, negativity. We should try to cultivate a habit of positive speech rather than negative.',
+    fr: 'Troisièmement, la négativité. Nous devrions essayer de cultiver une habitude de discours positif plutôt que négatif.',
+  },
+  {
+    startTimeInSecond: 70,
+    durationInSecond: 8,
+    ko: '부정적인 언어는 사람들을 멀어지게 하고, 대화의 흐름을 방해합니다. 우리는 긍정적인 언어를 통해 대화를 더욱 풍요롭게 할 수 있습니다.',
+    en: 'Negative speech can push people away and disrupt the flow of conversation. Through positive language, we can enrich our interactions.',
+    fr: 'Un discours négatif peut repousser les gens et perturber le cours de la conversation. Avec un langage positif, nous pouvons enrichir nos échanges.',
+  },
+  {
+    startTimeInSecond: 78.5,
+    durationInSecond: 5,
+    ko: '네 번째, 불평. 불평은 긍정적인 분위기를 해칩니다.',
+    en: 'Fourth, complaining. Complaining undermines a positive atmosphere.',
+    fr: 'Quatrièmement, se plaindre. Se plaindre nuit à une atmosphère positive.',
+  },
+  {
+    startTimeInSecond: 84,
+    durationInSecond: 7,
+    ko: '우리는 상황에 대해 불평하는 것 대신, 해결 방안을 모색하고, 긍정적인 태도를 유지하려고 노력해야 합니다.',
+    en: 'Instead of complaining about situations, we should focus on finding solutions and maintaining a positive attitude.',
+    fr: 'Au lieu de se plaindre des situations, nous devrions chercher des solutions et garder une attitude positive.',
+  },
+];
+
+export default subtitles;

--- a/src/components/VideoPlayer/utils/formatTime.ts
+++ b/src/components/VideoPlayer/utils/formatTime.ts
@@ -1,0 +1,11 @@
+// 시간을 mm:ss 형식으로 변환하는 함수
+const formatTime = (time: number | null) => {
+  if (time === null) return '0:00';
+  const minutes = Math.floor(time / 60);
+  const seconds = Math.floor(time % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};
+
+export default formatTime;


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 라이브러리 레포의 demo폴더를 애플리케이션 videoPlayer폴더로 코드만 복사
- Close #54 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

> 라이브러리의 데모 코드를 어플리케이션에서 사용하기 위해 그대로 코드만 복사해왔습니다.
단, 폴더 구조는 변경되었습니다.


VideoPlayer폴더 안에 reactScriptPlayer는 라이브러리 레포의 core폴더구조를 그대로 유지하면서 가져왔습니다.
![image](https://github.com/user-attachments/assets/4161d850-8c4b-46ec-9548-49a64a148156)



hydration error해결을 위해 
현님이 scss를 tailwind구문으로 바꿔주시기로 하셨습니다. 

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
