### PR TITLE
[fix] nextjs Image태그를 일반 img태그로 변경

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,8 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'avatar.iran.liara.run',
       },
+      { protocol: 'https', hostname: 'i.ytimg.com' }, // api로 받아오는 데이터 img주소 무조건 추가해줘야함
+      { protocol: 'https', hostname: 'yozm.wishket.com' }, // api로 받아오는 데이터 img주소 무조건 추가해줘야함
     ],
   },
   rewrites: async () => {

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -9,7 +9,6 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import { ArrowUp, Languages, MessageCircleMoreIcon } from 'lucide-react';
-import Image from 'next/image';
 import quizData from '@/mock/quizData.json';
 import QuizCarousel from '@/components/quiz/QuizCarousel';
 import Tooltip from '@/components/Tooltip';

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -240,7 +240,7 @@ export default function DetailReadingPage() {
   return (
     <>
       <div className="flex">
-        <div className="flex flex-col flex-1 gap-5 mx-auto p-5 pb-16 max-w-[800px]">
+        <div className="flex flex-col flex-1 gap-5 mx-auto p-5 pb-16 max-w-[800px] h-auto">
           <div>
             <Badge>{contentData.category}</Badge>
             <div className="font-bold text-2xl mt-2 mb-4">
@@ -250,10 +250,8 @@ export default function DetailReadingPage() {
           </div>
           <Separator />
           <div className="flex justify-center">
-            <Image
+            <img
               src={contentData.thumbnailUrl}
-              width={600}
-              height={400}
               alt="이미지"
               className="rounded-lg"
             />

--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -4,7 +4,6 @@
 import { Camera, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import Image from 'next/image';
 import { useEffect, useState, useMemo } from 'react';
 import { useUserInfo } from '@/api/hooks/useUserInfo';
 import { updateUserInfo } from '@/api/queries/userQueries';

--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -70,12 +70,10 @@ export default function UserProfile() {
       <div className="p-4 max-w-xl flex flex-col justify-center items-center mx-auto">
         <div className="flex justify-center mb-6">
           <div className="relative">
-            <Image
+            <img
               src="https://avatar.iran.liara.run/public/girl"
               alt="Profile"
               className="w-20 h-20 rounded-full"
-              width={80}
-              height={80}
             />
             {/* todo : 사진 버튼 눌렀을 때 마이페이지 추가 */}
             {/* <input type="file" /> */}

--- a/src/app/scrapbook/highlight/page.tsx
+++ b/src/app/scrapbook/highlight/page.tsx
@@ -39,7 +39,7 @@ export default function HighlighterAndMemo() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-6">형광펜과 메모</h1>
-      <p className="text-sm text-muted-foreground mb-4">12개의 형광펜</p>
+      <p className="text-sm text-muted-foreground">12개의 형광펜</p>
       {memoItems.map((item) => (
         <MemoItem key={item.id} item={item} />
       ))}

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -35,11 +35,9 @@ export default function ArticlePreview({ articlePreviewContent }: ContentItem) {
           </div>
           {thumbnail && (
             <div className="flex-shrink-0">
-              <Image
+              <img
                 src={thumbnail}
-                alt=""
-                fill
-                sizes="100%"
+                alt="scrapThumbnail"
                 className="rounded-md object-cover aspect-square"
               />
             </div>

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import Link from 'next/link';
 
 interface ContentItem {

--- a/src/components/ContentsCard.tsx
+++ b/src/components/ContentsCard.tsx
@@ -1,12 +1,11 @@
 import { Card, CardDescription, CardTitle } from '@/components/ui/card';
 import { AspectRatio } from '@/components/ui/aspect-ratio';
 import { Badge } from '@/components/ui/badge';
-import Image from 'next/image';
 import { formatViewCount } from '@/lib/utils';
 
 interface CardDataProps {
   id: number;
-  imageUrl: string;
+  thumbnailUrl: string;
   category: string;
   title: string;
   views: number;
@@ -16,12 +15,16 @@ function ContentsCard({ card }: { card: CardDataProps }) {
   return (
     <Card className="rounded-xl overflow-hidden shadow-mille">
       <AspectRatio ratio={16 / 9}>
-        <img src={card.imageUrl} alt={card.title} className="object-cover" />
+        <img
+          src={card.thumbnailUrl}
+          alt={card.title}
+          className="object-cover"
+        />
       </AspectRatio>
       <div className="p-4">
         <Badge className="rounded">{card.category}</Badge>
         <CardDescription className="mt-1 text-xs">
-          {formatViewCount(card.views)}
+          {formatViewCount(card.views)}thumbnailUrl
         </CardDescription>
         <CardTitle className="line-clamp-2 mt-1">{card.title}</CardTitle>
       </div>

--- a/src/components/ContentsCard.tsx
+++ b/src/components/ContentsCard.tsx
@@ -16,13 +16,7 @@ function ContentsCard({ card }: { card: CardDataProps }) {
   return (
     <Card className="rounded-xl overflow-hidden shadow-mille">
       <AspectRatio ratio={16 / 9}>
-        <Image
-          src={card.imageUrl}
-          alt={card.title}
-          className="object-cover"
-          fill
-          priority // Ensures fast loading for the first card
-        />
+        <img src={card.imageUrl} alt={card.title} className="object-cover" />
       </AspectRatio>
       <div className="p-4">
         <Badge className="rounded">{card.category}</Badge>

--- a/src/components/ListeningPreviewCard.tsx
+++ b/src/components/ListeningPreviewCard.tsx
@@ -9,7 +9,7 @@ import { Clock } from 'lucide-react';
 import { ListeningPreview } from '@/types/Preview';
 
 export default function ListeningPreviewCard({
-  data: { id, imageUrl, title, category },
+  data: { id, thumbnailUrl, title, category },
 }: {
   data: ListeningPreview;
 }) {
@@ -18,13 +18,7 @@ export default function ListeningPreviewCard({
       <Card className="w-80 h-46 max-w-sm overflow-hidden rounded-lg hover:shadow-card-hover">
         <CardContent className="p-0">
           <div className="relative w-80 h-44">
-            <Image
-              src={imageUrl}
-              alt={title}
-              fill
-              sizes="100%"
-              className="object-cover"
-            />
+            <img src={thumbnailUrl} alt={title} className="object-cover" />
             <Badge className="absolute bottom-2 right-2 flex items-center gap-1">
               <Clock className="w-3 h-3" />
               <span>24:00</span>

--- a/src/components/ListeningPreviewCard.tsx
+++ b/src/components/ListeningPreviewCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import Image from 'next/image';
 import { Card, CardContent } from '@/components/ui/card';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
@@ -9,7 +8,7 @@ import { Clock } from 'lucide-react';
 import { ListeningPreview } from '@/types/Preview';
 
 export default function ListeningPreviewCard({
-  data: { id, thumbnailUrl, title, category },
+  data: { id, imageUrl, title, category },
 }: {
   data: ListeningPreview;
 }) {
@@ -18,7 +17,7 @@ export default function ListeningPreviewCard({
       <Card className="w-80 h-46 max-w-sm overflow-hidden rounded-lg hover:shadow-card-hover">
         <CardContent className="p-0">
           <div className="relative w-80 h-44">
-            <img src={thumbnailUrl} alt={title} className="object-cover" />
+            <img src={imageUrl} alt={title} className="object-cover" />
             <Badge className="absolute bottom-2 right-2 flex items-center gap-1">
               <Clock className="w-3 h-3" />
               <span>24:00</span>

--- a/src/types/Preview.ts
+++ b/src/types/Preview.ts
@@ -2,7 +2,7 @@ export interface ListeningPreview {
   id: number;
   title: string;
   category: string;
-  imageUrl: string;
+  thumbnailUrl: string;
 }
 
 export interface ReadingPreview {

--- a/src/types/Preview.ts
+++ b/src/types/Preview.ts
@@ -2,7 +2,7 @@ export interface ListeningPreview {
   id: number;
   title: string;
   category: string;
-  thumbnailUrl: string;
+  imageUrl: string;
 }
 
 export interface ReadingPreview {


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : Hydration failed because the initial UI does not match what was rendered on the server.
See more info here: https://nextjs.org/docs/messages/react-hydration-error
- Close #71 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
서버에서 query params로 내려주는 height, width가 있는데 next/image에서 제공하는 Image 태그는 height, width를 무시하고 최적화하려고 하니 그와 관련된 에러가 발생할 수 있습니다. 
-> 결론 : Nextjs의 <Image> 대신 기본 <img>를 사용합시다. 



