### PR TITLE
feat : 학습 페이지 UI 구현 및 api 연결

### DIFF
--- a/src/api/hooks/usePreview.ts
+++ b/src/api/hooks/usePreview.ts
@@ -1,24 +1,36 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import {
+  fetchListeningContents,
   fetchListeningPreview,
+  fetchReadingContents,
   fetchReadingPreview,
 } from '../queries/contentsQueries';
-import {
-  ListeningPreviewResponse,
-  ReadingPreviewResponse,
-} from '../../types/Preview';
+import { ContentsResponse, PreviewResponse } from '../../types/Preview';
 
-export const useReadingPreview = (): UseQueryResult<ReadingPreviewResponse> => {
+export const useReadingPreview = (): UseQueryResult<PreviewResponse> => {
   return useQuery({
     queryKey: ['readingPreviewData'],
     queryFn: () => fetchReadingPreview(),
   });
 };
 
-export const useListeningPreview =
-  (): UseQueryResult<ListeningPreviewResponse> => {
-    return useQuery({
-      queryKey: ['listeningPreviewData'],
-      queryFn: () => fetchListeningPreview(),
-    });
-  };
+export const useListeningPreview = (): UseQueryResult<PreviewResponse> => {
+  return useQuery({
+    queryKey: ['listeningPreviewData'],
+    queryFn: () => fetchListeningPreview(),
+  });
+};
+
+export const useReadingContents = (): UseQueryResult<ContentsResponse> => {
+  return useQuery({
+    queryKey: ['readingContentsData'],
+    queryFn: () => fetchReadingContents(),
+  });
+};
+
+export const useListeningContents = (): UseQueryResult<ContentsResponse> => {
+  return useQuery({
+    queryKey: ['listeningContentsData'],
+    queryFn: () => fetchListeningContents(),
+  });
+};

--- a/src/api/queries/contentsQueries.ts
+++ b/src/api/queries/contentsQueries.ts
@@ -1,49 +1,77 @@
-import {
-  ListeningPreviewResponse,
-  ReadingPreviewResponse,
-} from '@/types/Preview';
+import { PreviewResponse, ContentsResponse } from '@/types/Preview';
 import { ContentDetailResponse } from '../../types/ContentDetail';
 
 const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api/contents`;
 
-export const fetchReadingPreview =
-  async (): Promise<ReadingPreviewResponse> => {
-    const response = await fetch(`${BASE_URL}/preview/reading`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-    });
+export const fetchReadingPreview = async (): Promise<PreviewResponse> => {
+  const response = await fetch(`${BASE_URL}/preview/reading`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
 
-    return response.json();
-  };
+  return response.json();
+};
 
-export const fetchListeningPreview =
-  async (): Promise<ListeningPreviewResponse> => {
-    const response = await fetch(`${BASE_URL}/preview/listening`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-    });
+export const fetchListeningPreview = async (): Promise<PreviewResponse> => {
+  const response = await fetch(`${BASE_URL}/preview/listening`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
 
-    return response.json();
-  };
+  return response.json();
+};
 
 export const fetchContentDetail = async (
   contentId: number,
 ): Promise<ContentDetailResponse> => {
   const response = await fetch(`${BASE_URL}/details/${contentId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+// TODO(@smosco):query param으로 정렬, 카테고리, 사이즈 조절 넘기기
+export const fetchReadingContents = async (): Promise<ContentsResponse> => {
+  const response = await fetch(`${BASE_URL}/view/reading`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+export const fetchListeningContents = async (): Promise<ContentsResponse> => {
+  const response = await fetch(`${BASE_URL}/view/listening`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/src/app/learn/layout.tsx
+++ b/src/app/learn/layout.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+function ContentTypeFilter() {
+  const path = usePathname();
+
+  const linkItems = [
+    { href: '/learn/listening', label: '리스닝', key: 'listening' },
+    { href: '/learn/reading', label: '리딩', key: 'reading' },
+  ];
+
+  return (
+    <div className="flex space-x-2">
+      {linkItems.map(({ href, label, key }) => {
+        const isActive = path === href;
+
+        return (
+          <Link key={key} href={href}>
+            <Button
+              variant={isActive ? 'default' : 'outline'}
+              className="rounded-full px-4 py-2 text-sm font-medium"
+            >
+              {label}
+            </Button>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function LearnPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="max-w-[1080px] mx-auto pt-12 px-6">
+      <ContentTypeFilter />
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/src/app/learn/listening/page.tsx
+++ b/src/app/learn/listening/page.tsx
@@ -1,19 +1,39 @@
-'use Client';
+'use client';
 
-import listeningList from '@/mock/listeningList.json';
-// import ContentsCard from '@/components/ContentsCard';
 import ListeningPreviewCard from '@/components/ListeningPreviewCard';
+import { useListeningContents } from '@/api/hooks/usePreview';
 
-function listeningPage() {
+function ListeningPage() {
+  const {
+    data: listeningContents,
+    isLoading,
+    isError,
+    error,
+  } = useListeningContents();
+
+  if (isLoading) {
+    return <p className="mt-8">로딩 중...</p>;
+  }
+
+  if (isError) {
+    return (
+      <p className="mt-8 text-red-500">에러가 발생했습니다: {error.message}</p>
+    );
+  }
+
+  if (!listeningContents || listeningContents.data.contents.length === 0) {
+    return <p className="mt-8">콘텐츠가 없습니다.</p>;
+  }
+
   return (
-    <main className="max-w-[1440px] mx-auto px-6 py-8">
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 m">
-        {listeningList.map((card) => (
-          <ListeningPreviewCard key={card.contentId} data={card} />
+    <main className="mt-8">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+        {listeningContents.data.contents.map((content) => (
+          <ListeningPreviewCard key={content.contentId} data={content} />
         ))}
       </div>
     </main>
   );
 }
 
-export default listeningPage;
+export default ListeningPage;

--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -1,3 +1,0 @@
-export default function learnPage() {
-  return <div className="max-w-[1440px] mx-auto">학습 페이지</div>;
-}

--- a/src/app/learn/reading/page.tsx
+++ b/src/app/learn/reading/page.tsx
@@ -1,14 +1,35 @@
+'use client';
+
 import ArticlePreview from '@/components/ArticlePreview';
-import readingList from '@/mock/readingList.json';
+import { useReadingContents } from '@/api/hooks/usePreview';
 
 export default function ReadingPage() {
+  const {
+    data: readingContents,
+    isLoading,
+    isError,
+    error,
+  } = useReadingContents();
+
+  if (isLoading) {
+    return <p className="mt-8">로딩 중...</p>;
+  }
+
+  if (isError) {
+    return (
+      <p className="mt-8 text-red-500">에러가 발생했습니다: {error.message}</p>
+    );
+  }
+
+  if (!readingContents || readingContents.data.contents.length === 0) {
+    return <p className="mt-8">콘텐츠가 없습니다.</p>;
+  }
+
   return (
-    <div className="max-w-[1080px] mx-auto pt-12">
+    <div className="mt-8">
       <ul className="flex flex-col gap-4">
-        {readingList.map((item) => (
-          <li key={item.id}>
-            <ArticlePreview articlePreviewContent={item} />
-          </li>
+        {readingContents.data.contents.map((content) => (
+          <ArticlePreview key={content.contentId} data={content} />
         ))}
       </ul>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function HomePage() {
   }
 
   return (
-    <div className="max-w-[1080px] mx-auto mt-8 mb-24 flex flex-col gap-12">
+    <div className="max-w-[1080px] mx-auto mt-12 px-6 mb-24 flex flex-col gap-12">
       {/* 인기 리스닝 컨텐츠 캐러셀 */}
       <Carousel
         previewDatas={readingList?.data || []}

--- a/src/app/scrapbook/content/page.tsx
+++ b/src/app/scrapbook/content/page.tsx
@@ -1,54 +1,54 @@
-import ArticlePreview from '@/components/ArticlePreview';
+// import ArticlePreview from '@/components/ArticlePreview';
 
-interface ContentItem {
-  id: number;
-  title: string;
-  author: string;
-  date: string;
-  description: string;
-  thumbnail?: string;
-}
+// interface ContentItem {
+//   id: number;
+//   title: string;
+//   author: string;
+//   date: string;
+//   description: string;
+//   thumbnail?: string;
+// }
 
-const contentItems: ContentItem[] = [
-  {
-    id: 1,
-    title: '기획자가 알아야 할 건 왜 이렇게 많아요? 용어·개념 A to Z',
-    author: 'smosco님의 스크랩북',
-    date: '2024. 10. 10. 저장',
-    description:
-      '주석을 달아 유용IT가 글 모음 선물을 준비했습니다. 이번 주제는 기획자가 알아야 할 기획 용어와 개념 모음입니다. 기획자는 프로젝트의 방향을 정하고 팀을 이끄는 중요한 역할을 맡고 있습니다. 이러한 역할...',
-    thumbnail:
-      'https://images.unsplash.com/photo-1573496267526-08a69e46a409?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    id: 2,
-    title: 'AI도 UX 리서처가 될 수 있을까? AI 모더레이터 툴 리뷰',
-    author: 'smosco님의 스크랩북',
-    date: '2024. 10. 10. 저장',
-    description:
-      '최근 몇 년간 UX 리서치 분야에서 인공지능(AI)의 도입이 급격히 증가하고 있습니다. 과거에는 AI를 연구에 활용할 때 단순히 반복 작업을 자동화하거나, 빅데이터를 업무를 줄여주는 역할에 그칠 것이라 예상했지만, ...',
-    thumbnail:
-      'https://images.unsplash.com/photo-1573496267526-08a69e46a409?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    id: 3,
-    title: '개발자는 정말로 사라질까?',
-    author: 'smosco님의 스크랩북',
-    date: '2024. 10. 10. 저장',
-    description:
-      '주석을 달아 유용IT가 글 모음 선물을 준비했습니다. 이번 주제는 개발자의 미래입니다. 빠르게 성장하는 AI 도구가 개발의 영역을 침범하고 있습니다. 누군가는 개발자란 직업의 종말을, 누군가는 새로운 전성을,...',
-    thumbnail:
-      'https://images.unsplash.com/photo-1573496267526-08a69e46a409?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-];
+// const contentItems: ContentItem[] = [
+//   {
+//     id: 1,
+//     title: '기획자가 알아야 할 건 왜 이렇게 많아요? 용어·개념 A to Z',
+//     author: 'smosco님의 스크랩북',
+//     date: '2024. 10. 10. 저장',
+//     description:
+//       '주석을 달아 유용IT가 글 모음 선물을 준비했습니다. 이번 주제는 기획자가 알아야 할 기획 용어와 개념 모음입니다. 기획자는 프로젝트의 방향을 정하고 팀을 이끄는 중요한 역할을 맡고 있습니다. 이러한 역할...',
+//     thumbnail:
+//       'https://images.unsplash.com/photo-1573496267526-08a69e46a409?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+//   },
+//   {
+//     id: 2,
+//     title: 'AI도 UX 리서처가 될 수 있을까? AI 모더레이터 툴 리뷰',
+//     author: 'smosco님의 스크랩북',
+//     date: '2024. 10. 10. 저장',
+//     description:
+//       '최근 몇 년간 UX 리서치 분야에서 인공지능(AI)의 도입이 급격히 증가하고 있습니다. 과거에는 AI를 연구에 활용할 때 단순히 반복 작업을 자동화하거나, 빅데이터를 업무를 줄여주는 역할에 그칠 것이라 예상했지만, ...',
+//     thumbnail:
+//       'https://images.unsplash.com/photo-1573496267526-08a69e46a409?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+//   },
+//   {
+//     id: 3,
+//     title: '개발자는 정말로 사라질까?',
+//     author: 'smosco님의 스크랩북',
+//     date: '2024. 10. 10. 저장',
+//     description:
+//       '주석을 달아 유용IT가 글 모음 선물을 준비했습니다. 이번 주제는 개발자의 미래입니다. 빠르게 성장하는 AI 도구가 개발의 영역을 침범하고 있습니다. 누군가는 개발자란 직업의 종말을, 누군가는 새로운 전성을,...',
+//     thumbnail:
+//       'https://images.unsplash.com/photo-1573496267526-08a69e46a409?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+//   },
+// ];
 
 export default function RecentContent() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-6">최근 스크랩한 콘텐츠</h1>
-      {contentItems.map((item) => (
+      {/* {contentItems.map((item) => (
         <ArticlePreview key={item.id} articlePreviewContent={item} />
-      ))}
+      ))} */}
     </div>
   );
 }

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -1,41 +1,31 @@
+import { Preview } from '@/types/Preview';
 import Link from 'next/link';
+import { removeFirstChar } from '@/lib/removeFirstChar';
 
-interface ContentItem {
-  articlePreviewContent: {
-    id: number;
-    title: string;
-    author?: string;
-    date?: string;
-    views?: string;
-    description: string;
-    thumbnail?: string;
-  };
-}
-
-export default function ArticlePreview({ articlePreviewContent }: ContentItem) {
-  const { id, title, description, thumbnail } = articlePreviewContent;
+export default function ArticlePreview({
+  // TODO(@smosco): hits, 북마크 아이콘 추가
+  data: { contentId, thumbnailUrl, title, category, preScripts, hits },
+}: {
+  data: Preview;
+}) {
   return (
-    <Link href={`/learn/reading/detail/${id}`}>
+    <Link href={`/learn/reading/detail/${contentId}`}>
       <div className="py-6 border-b border-gray-200">
         <div className="flex justify-between items-start">
           <div className="flex-1 pr-4">
             <h2 className="text-lg font-semibold mb-2 hover:underline underline-offset-2">
               {title}
             </h2>
-            <p className="text-sm text-muted-foreground mb-3">
-              {articlePreviewContent.views && articlePreviewContent.views}
-              {articlePreviewContent.date && articlePreviewContent.date}
-              {articlePreviewContent.author &&
-                `· ${articlePreviewContent.author}`}
-            </p>
+            <p className="text-sm mb-3">{category}</p>
+            <p className="text-sm text-muted-foreground mb-3">{hits}회</p>
             <p className="text-sm text-muted-foreground line-clamp-2">
-              {description}
+              {removeFirstChar(preScripts)}
             </p>
           </div>
-          {thumbnail && (
+          {thumbnailUrl && (
             <div className="flex-shrink-0 w-24">
               <img
-                src={thumbnail}
+                src={thumbnailUrl}
                 alt="scrapThumbnail"
                 className="rounded-md object-cover aspect-square"
               />

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -50,7 +50,7 @@ export default function Carousel<T>({
   }, [currentIndex, itemWidth]);
 
   return (
-    <div className="relative max-w-[1440px] w-full mx-auto px-4">
+    <div className="relative w-full mx-auto">
       {/* Carousel Header */}
       {header && header}
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@/components/ui/button';
 
 export const navItems = [
-  { name: '학습', href: '/learn', icon: BookHeadphones },
+  { name: '학습', href: '/learn/listening', icon: BookHeadphones },
   { name: '검색', href: '/search', icon: Search },
   { name: '스크랩', href: '/scrapbook/content', icon: Bookmark },
   { name: '마이페이지', href: '/mypage/profile', icon: CircleUserRound },

--- a/src/components/ListeningPreviewCard.tsx
+++ b/src/components/ListeningPreviewCard.tsx
@@ -5,21 +5,25 @@ import { Card, CardContent } from '@/components/ui/card';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { Clock } from 'lucide-react';
-import { ListeningPreview } from '@/types/Preview';
+import { Preview } from '@/types/Preview';
 import { removeFirstChar } from '@/lib/removeFirstChar';
 
 export default function ListeningPreviewCard({
-  // TODO(@smosco): hits 추가
+  // TODO(@smosco): hits, 북마크 아이콘 추가
   data: { contentId, thumbnailUrl, title, category, preScripts },
 }: {
-  data: ListeningPreview;
+  data: Preview;
 }) {
   return (
     <Link href={`/learn/listening/detail/${contentId}`} className="mr-3">
-      <Card className="w-80 h-46 max-w-sm overflow-hidden rounded-lg hover:shadow-card-hover">
+      <Card className="w-full max-w-xs overflow-hidden rounded-lg hover:shadow-card-hover">
         <CardContent className="p-0">
-          <div className="relative w-80 h-44">
-            <img src={thumbnailUrl} alt={title} className="object-cover" />
+          <div className="relative w-full h-44">
+            <img
+              src={thumbnailUrl}
+              alt={title}
+              className="w-full h-full object-cover"
+            />
             <Badge className="absolute bottom-2 right-2 flex items-center gap-1">
               <Clock className="w-3 h-3" />
               <span>24:00</span>

--- a/src/components/ReadingPreviewCard.tsx
+++ b/src/components/ReadingPreviewCard.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Card, CardContent } from '@/components/ui/card';
-import { ReadingPreview } from '@/types/Preview';
+import { Preview } from '@/types/Preview';
 import { removeFirstChar } from '@/lib/removeFirstChar';
 import { Badge } from './ui/badge';
 
@@ -12,7 +12,7 @@ export default function ReadingPreviewCard({
   // TODO(@smosco):hits 추가
   data: { contentId, thumbnailUrl, title, category, preScripts },
 }: {
-  data: ReadingPreview;
+  data: Preview;
 }) {
   return (
     <Link href={`/learn/reading/detail/${contentId}`}>

--- a/src/types/Preview.ts
+++ b/src/types/Preview.ts
@@ -1,4 +1,4 @@
-export interface ListeningPreview {
+export interface Preview {
   contentId: number;
   title: string;
   category: string;
@@ -7,23 +7,20 @@ export interface ListeningPreview {
   hits: number;
 }
 
-export interface ReadingPreview {
-  contentId: number;
-  title: string;
-  category: string;
-  thumbnailUrl: string;
-  preScripts: string;
-  hits: number;
+export interface PreviewResponse {
+  code: string;
+  message: string;
+  data: Preview[];
 }
 
-export type ListeningPreviewResponse = {
+export type ContentsResponse = {
   code: string;
   message: string;
-  data: ListeningPreview[];
-};
-
-export type ReadingPreviewResponse = {
-  code: string;
-  message: string;
-  data: ReadingPreview[];
+  data: {
+    pageNumber: number;
+    pageSize: number;
+    totlaPages: number;
+    totlaElements: number;
+    contents: Preview[];
+  };
 };


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 학습 페이지 UI를 구현하고 API를 연결했습니다.
- Close #80 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- 학습 페이지 layout에 contentTypeFilter를 추가했습니다.
- 리딩, 리스닝 콘텐츠 가져오는 훅을 추가했습니다
- 리딩, 리스닝 콘텐츠, 프리뷰 콘텐츠가 데이터 타입이 거의 비슷해서 기존에 중복되던 응답 타입을 제거했습니다.
- 리스닝 프리뷰 카드가 grid 적용할 때 크기가 제각각이 되던 문제를 해결했습니다. img에 고정된 크기를 주던 것 때문에 발생했습니다.

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/de9dd19f-b3c8-4865-a8f6-3fb55008e522)

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
- 아직 리딩 리스닝 콘텐츠 가져오는 함수에 카테고리, 정렬 방식, 사이즈를 쿼리 파라미터로 넘기는 건 구현하지 않았습니다.
- 스크랩을 프리뷰에서도 가능하도록 아이콘을 추가하려고 합니다. 

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
