### PR TITLE
feat : 스크랩 페이지의 북마크 수정, 삭제, 전체 불러오기 기능 구현

### DIFF
--- a/src/api/hooks/useBookmarks.ts
+++ b/src/api/hooks/useBookmarks.ts
@@ -1,18 +1,30 @@
 // src/api/hooks/useBookmarks.ts
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { BookmarkResponse, Bookmark } from '../../types/Bookmark';
 import {
-  fetchBookmarks,
+  BookmarkListResponse,
+  BookmarkByContentIdResponse,
+  Bookmark,
+} from '../../types/Bookmark';
+import {
+  fetchBookmarksByContentId,
+  fetchAllBookmarks,
   createBookmark,
   updateBookmark,
   deleteBookmark,
 } from '../queries/bookmarkQueries';
 
 // 북마크 조회 훅
-export const useFetchBookmarks = (contentId: number) => {
-  return useQuery<BookmarkResponse>({
+export const useFetchBookmarksByContendId = (contentId: number) => {
+  return useQuery<BookmarkByContentIdResponse>({
     queryKey: ['bookmarks', contentId],
-    queryFn: () => fetchBookmarks(contentId),
+    queryFn: () => fetchBookmarksByContentId(contentId),
+  });
+};
+
+export const useFetchAllBookmarks = () => {
+  return useQuery<BookmarkListResponse>({
+    queryKey: ['bookmarks'],
+    queryFn: () => fetchAllBookmarks(),
   });
 };
 

--- a/src/api/hooks/usePreview.ts
+++ b/src/api/hooks/usePreview.ts
@@ -5,21 +5,26 @@ import {
   fetchReadingContents,
   fetchReadingPreview,
 } from '../queries/contentsQueries';
-import { ContentsResponse, PreviewResponse } from '../../types/Preview';
+import {
+  ContentsResponse,
+  ListeningPreviewResponse,
+  ReadingPreviewResponse,
+} from '../../types/Preview';
 
-export const useReadingPreview = (): UseQueryResult<PreviewResponse> => {
+export const useReadingPreview = (): UseQueryResult<ReadingPreviewResponse> => {
   return useQuery({
     queryKey: ['readingPreviewData'],
     queryFn: () => fetchReadingPreview(),
   });
 };
 
-export const useListeningPreview = (): UseQueryResult<PreviewResponse> => {
-  return useQuery({
-    queryKey: ['listeningPreviewData'],
-    queryFn: () => fetchListeningPreview(),
-  });
-};
+export const useListeningPreview =
+  (): UseQueryResult<ListeningPreviewResponse> => {
+    return useQuery({
+      queryKey: ['listeningPreviewData'],
+      queryFn: () => fetchListeningPreview(),
+    });
+  };
 
 export const useReadingContents = (): UseQueryResult<ContentsResponse> => {
   return useQuery({

--- a/src/api/hooks/useScrap.ts
+++ b/src/api/hooks/useScrap.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  FetchScrapResponse,
+  CreateScrapResponse,
+  DeleteScrapResponse,
+} from '@/types/Scrap';
+import { fetchScrap, deleteScrap, createScrap } from '../queries/scrapQueries';
+
+// 스크랩 조회 훅
+export const useFetchScrap = () => {
+  return useQuery<FetchScrapResponse>({
+    queryKey: ['scrap'],
+    queryFn: () => fetchScrap(),
+  });
+};
+
+// 스크랩 생성 훅
+export const useCreateScrap = (contentId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<CreateScrapResponse, Error>({
+    mutationFn: () => createScrap(contentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scrap'] });
+    },
+  });
+};
+
+// 스크랩 삭제 훅
+export const useDeleteScrap = (contentId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<DeleteScrapResponse, Error>({
+    mutationFn: () => deleteScrap(contentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scrap'] });
+    },
+  });
+};

--- a/src/api/queries/bookmarkQueries.ts
+++ b/src/api/queries/bookmarkQueries.ts
@@ -1,18 +1,33 @@
-import { Bookmark, BookmarkResponse } from '../../types/Bookmark';
+import {
+  Bookmark,
+  BookmarkListResponse,
+  BookmarkByContentIdResponse,
+} from '../../types/Bookmark';
 
 const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api/bookmark`;
 
-// 북마크 조회 (GET)
-export const fetchBookmarks = async (
+export const fetchAllBookmarks = async (): Promise<BookmarkListResponse> => {
+  const response = await fetch(`${BASE_URL}/view`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to fetch all bookmarks');
+  }
+  return response.json();
+};
+
+export const fetchBookmarksByContentId = async (
   contentId: number,
-): Promise<BookmarkResponse> => {
+): Promise<BookmarkByContentIdResponse> => {
   const response = await fetch(`${BASE_URL}/view/${contentId}`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
   });
   if (!response.ok) {
-    throw new Error('Failed to fetch bookmarks');
+    throw new Error('Failed to fetch bookmarks by content ID');
   }
   return response.json();
 };

--- a/src/api/queries/contentsQueries.ts
+++ b/src/api/queries/contentsQueries.ts
@@ -1,39 +1,45 @@
-import { PreviewResponse, ContentsResponse } from '@/types/Preview';
+import {
+  ReadingPreviewResponse,
+  ListeningPreviewResponse,
+  ContentsResponse,
+} from '@/types/Preview';
 import { ContentDetailResponse } from '../../types/ContentDetail';
 
 const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api/contents`;
 
-export const fetchReadingPreview = async (): Promise<PreviewResponse> => {
-  const response = await fetch(`${BASE_URL}/preview/reading`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    credentials: 'include',
-  });
+export const fetchReadingPreview =
+  async (): Promise<ReadingPreviewResponse> => {
+    const response = await fetch(`${BASE_URL}/preview/reading`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
 
-  return response.json();
-};
+    return response.json();
+  };
 
-export const fetchListeningPreview = async (): Promise<PreviewResponse> => {
-  const response = await fetch(`${BASE_URL}/preview/listening`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    credentials: 'include',
-  });
+export const fetchListeningPreview =
+  async (): Promise<ListeningPreviewResponse> => {
+    const response = await fetch(`${BASE_URL}/preview/listening`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
 
-  return response.json();
-};
+    return response.json();
+  };
 
 export const fetchContentDetail = async (
   contentId: number,

--- a/src/api/queries/scrapQueries.ts
+++ b/src/api/queries/scrapQueries.ts
@@ -1,0 +1,50 @@
+import {
+  FetchScrapResponse,
+  CreateScrapResponse,
+  DeleteScrapResponse,
+} from '@/types/Scrap';
+
+const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api/admin/scrap`;
+
+// 스크랩 조회
+export const fetchScrap = async (): Promise<FetchScrapResponse> => {
+  const response = await fetch(BASE_URL, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to fetch scrap');
+  }
+  return response.json();
+};
+
+// 스크랩 생성
+export const createScrap = async (
+  contentId: number,
+): Promise<CreateScrapResponse> => {
+  const response = await fetch(BASE_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ contentId }),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to create scrap');
+  }
+  return response.json();
+};
+
+// 스크랩 삭제
+export const deleteScrap = async (
+  contentId: number,
+): Promise<DeleteScrapResponse> => {
+  const response = await fetch(`${BASE_URL}?contentId=${contentId}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to delete scrap');
+  }
+  return response.json();
+};

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -16,7 +16,7 @@ import MemoInput from '@/components/MemoInput';
 import Modal from '@/components/Modal';
 import { useContentDetail } from '@/api/hooks/useContentDetail';
 import {
-  useFetchBookmarks,
+  useFetchBookmarksByContendId,
   useCreateBookmark,
   useUpdateBookmark,
   useDeleteBookmark,
@@ -30,7 +30,7 @@ export default function DetailReadingPage() {
 
   // 북마크 데이터 훅
   const { data: bookmarkData, refetch: refetchBookmarks } =
-    useFetchBookmarks(contentId);
+    useFetchBookmarksByContendId(contentId);
   const createBookmarkMutation = useCreateBookmark(contentId);
   const updateBookmarkMutation = useUpdateBookmark(contentId);
   const deleteBookmarkMutation = useDeleteBookmark(contentId);
@@ -75,7 +75,7 @@ export default function DetailReadingPage() {
   // 북마크 추가 및 삭제 모달 표시 처리 함수
   const handleAddBookmark = () => {
     if (selectedSentenceIndex !== null) {
-      const existingBookmark = bookmarkData?.data.some(
+      const existingBookmark = bookmarkData?.data.bookmarkList.some(
         (item) => item.sentenceIndex === selectedSentenceIndex,
       );
 
@@ -104,7 +104,7 @@ export default function DetailReadingPage() {
   // 삭제 확인 시 실행
   const handleDeleteBookmark = () => {
     if (selectedSentenceIndex !== null) {
-      const bookmarkToDelete = bookmarkData?.data.find(
+      const bookmarkToDelete = bookmarkData?.data.bookmarkList.find(
         (item) => item.sentenceIndex === selectedSentenceIndex,
       );
 
@@ -140,7 +140,7 @@ export default function DetailReadingPage() {
     }
 
     // React Query 캐시에서 기존 메모 데이터를 가져옴
-    const existingMemo = bookmarkData?.data.find(
+    const existingMemo = bookmarkData?.data.bookmarkList.find(
       (item) => item.sentenceIndex === selectedSentenceIndex,
     );
 
@@ -184,7 +184,7 @@ export default function DetailReadingPage() {
   const handleSaveMemo = () => {
     if (selectedSentenceIndex === null) return;
 
-    const existingMemo = bookmarkData?.data.find(
+    const existingMemo = bookmarkData?.data.bookmarkList.find(
       (item) => item.sentenceIndex === selectedSentenceIndex,
     );
     const memoTextTrimmed = memoText.trim();
@@ -260,7 +260,7 @@ export default function DetailReadingPage() {
           <div>
             <ul className="flex flex-col gap-4 text-[#313131]">
               {contentData.scriptList.map((script, index) => {
-                const bookmarkMemo = bookmarkData?.data.find(
+                const bookmarkMemo = bookmarkData?.data.bookmarkList.find(
                   (item) => item.sentenceIndex === index,
                 );
                 return (
@@ -304,7 +304,7 @@ export default function DetailReadingPage() {
                 onAddBookmark={handleAddBookmark}
                 onAddMemo={handleMemoClick}
                 onClose={() => setTooltipVisible(false)}
-                isBookmarked={bookmarkData?.data.some(
+                isBookmarked={bookmarkData?.data.bookmarkList.some(
                   (item) => item.sentenceIndex === selectedSentenceIndex, // sentenceIndex로 비교
                 )}
               />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
     <div className="max-w-[1080px] mx-auto mt-12 px-6 mb-24 flex flex-col gap-12">
       {/* 인기 리스닝 컨텐츠 캐러셀 */}
       <Carousel
-        previewDatas={readingList?.data || []}
+        previewDatas={readingList?.data.readingPreview || []}
         header={
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-xl font-bold">인기 리딩 컨텐츠</h3>
@@ -38,7 +38,7 @@ export default function HomePage() {
       />
       {/* 인기 리딩 컨텐츠 캐러셀 */}
       <Carousel
-        previewDatas={listeningList?.data || []}
+        previewDatas={listeningList?.data.listeningPreview || []}
         header={
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-xl font-bold">인기 리스닝 컨텐츠</h3>

--- a/src/app/scrapbook/highlight/page.tsx
+++ b/src/app/scrapbook/highlight/page.tsx
@@ -1,76 +1,15 @@
 'use client';
 
 import MemoItem from '@/components/MemoItem';
-import { useFetchBookmarks } from '@/api/hooks/useBookmarks';
-// import { Bookmark } from '@/types/Bookmark';
-
-interface MemoItemProps {
-  contentId: number;
-  contentTitle: string;
-  bookmarkId: number;
-  bookmarkSentence: string;
-  description: string | null;
-  timestamp: number;
-}
-
-const memoItems: MemoItemProps[] = [
-  {
-    contentId: 1,
-    contentTitle: 'The Future of Artificial Intelligence',
-    bookmarkId: 101,
-    bookmarkSentence:
-      'Artificial intelligence is poised to transform industries in ways we cannot yet imagine.',
-    description:
-      'AI가 산업을 어떻게 변화시킬지 상상할 수 없다는 부분이 인상 깊다.',
-    timestamp: 1620304873,
-  },
-  {
-    contentId: 2,
-    contentTitle: 'Exploring Space: The New Frontier',
-    bookmarkId: 102,
-    bookmarkSentence:
-      'Space exploration has always been a symbol of human curiosity and ambition.',
-    description:
-      '우주 탐사가 인간의 호기심과 야망을 상징한다는 문장이 마음에 들었다.',
-    timestamp: 1620354873,
-  },
-  {
-    contentId: 3,
-    contentTitle: 'The Impact of Climate Change',
-    bookmarkId: 103,
-    bookmarkSentence:
-      'Climate change is the most significant challenge humanity faces today.',
-    description:
-      '기후 변화가 인류가 직면한 가장 큰 도전이라는 문장이 기억에 남는다.',
-    timestamp: 1620404873,
-  },
-  {
-    contentId: 4,
-    contentTitle: 'Technological Advancements in Medicine',
-    bookmarkId: 104,
-    bookmarkSentence:
-      'Medical technology is advancing at a pace never seen before.',
-    description: '의료 기술이 전에 없던 속도로 발전하고 있다는 점이 흥미롭다.',
-    timestamp: 1620454873,
-  },
-  {
-    contentId: 5,
-    contentTitle: 'Understanding Quantum Computing',
-    bookmarkId: 105,
-    bookmarkSentence:
-      'Quantum computing promises to revolutionize the field of computation.',
-    description: null,
-    timestamp: 1620504873,
-  },
-];
+import { useFetchAllBookmarks } from '@/api/hooks/useBookmarks';
 
 export default function HighlighterAndMemo() {
   const {
-    data: bookmarkDatas,
+    data: allBookmarkData,
     isLoading,
     isError,
     error,
-  } = useFetchBookmarks(1);
+  } = useFetchAllBookmarks();
 
   if (isLoading) {
     return <p className="mt-8">로딩 중...</p>;
@@ -82,7 +21,7 @@ export default function HighlighterAndMemo() {
     );
   }
 
-  if (!bookmarkDatas || bookmarkDatas.data.length === 0) {
+  if (!allBookmarkData || allBookmarkData.data.bookmarkMyList.length === 0) {
     return <p className="mt-8">북마크가 없습니다.</p>;
   }
 
@@ -90,9 +29,9 @@ export default function HighlighterAndMemo() {
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-6">형광펜과 메모</h1>
       <p className="text-sm text-muted-foreground">
-        {bookmarkDatas.data.length}개의 형광펜
+        {allBookmarkData.data.bookmarkMyList.length}개의 형광펜
       </p>
-      {memoItems.map((item) => (
+      {allBookmarkData.data.bookmarkMyList.map((item) => (
         <MemoItem key={item.bookmarkId} data={item} />
       ))}
     </div>

--- a/src/app/scrapbook/highlight/page.tsx
+++ b/src/app/scrapbook/highlight/page.tsx
@@ -1,47 +1,99 @@
 'use client';
 
 import MemoItem from '@/components/MemoItem';
+import { useFetchBookmarks } from '@/api/hooks/useBookmarks';
+// import { Bookmark } from '@/types/Bookmark';
 
 interface MemoItemProps {
-  id: string;
-  title: string;
-  content: string;
-  timestamp: string;
-  description?: string;
+  contentId: number;
+  contentTitle: string;
+  bookmarkId: number;
+  bookmarkSentence: string;
+  description: string | null;
+  timestamp: number;
 }
 
 const memoItems: MemoItemProps[] = [
   {
-    id: '1',
-    title: "제GPT보다 좋다고? '클로드'로 업무 생산성 높이기",
-    content:
-      '여러 기능을 살펴보고, 더 나아가 ChatGPT와 클로드, 두 강력한 생성형 AI를 어떻게 상황에 맞게 활용하여 업무 생산성을 극대화할 수 있는지 알아보겠습니다',
-    timestamp: '2024.10.09. 오후 18:48 저장',
+    contentId: 1,
+    contentTitle: 'The Future of Artificial Intelligence',
+    bookmarkId: 101,
+    bookmarkSentence:
+      'Artificial intelligence is poised to transform industries in ways we cannot yet imagine.',
     description:
-      '이 글은 AI 도구들의 비교와 활용에 대해 다루고 있어 유용해 보입니다.',
+      'AI가 산업을 어떻게 변화시킬지 상상할 수 없다는 부분이 인상 깊다.',
+    timestamp: 1620304873,
   },
   {
-    id: '2',
-    title: "제GPT보다 좋다고? '클로드'로 업무 생산성 높이기",
-    content: "AI 모델 이름에 예술적 감성을 담아왔습니다. 'Haiku'",
-    timestamp: '2024.10.09. 오후 16:38 저장',
-    description: 'AI 모델 이름의 의미에 대해 더 알아보고 싶습니다.',
+    contentId: 2,
+    contentTitle: 'Exploring Space: The New Frontier',
+    bookmarkId: 102,
+    bookmarkSentence:
+      'Space exploration has always been a symbol of human curiosity and ambition.',
+    description:
+      '우주 탐사가 인간의 호기심과 야망을 상징한다는 문장이 마음에 들었다.',
+    timestamp: 1620354873,
   },
   {
-    id: '3',
-    title: "제GPT보다 좋다고? '클로드'로 업무 생산성 높이기",
-    content: '테스트 포맷팅이',
-    timestamp: '2024.10.09. 오후 16:12 저장',
+    contentId: 3,
+    contentTitle: 'The Impact of Climate Change',
+    bookmarkId: 103,
+    bookmarkSentence:
+      'Climate change is the most significant challenge humanity faces today.',
+    description:
+      '기후 변화가 인류가 직면한 가장 큰 도전이라는 문장이 기억에 남는다.',
+    timestamp: 1620404873,
+  },
+  {
+    contentId: 4,
+    contentTitle: 'Technological Advancements in Medicine',
+    bookmarkId: 104,
+    bookmarkSentence:
+      'Medical technology is advancing at a pace never seen before.',
+    description: '의료 기술이 전에 없던 속도로 발전하고 있다는 점이 흥미롭다.',
+    timestamp: 1620454873,
+  },
+  {
+    contentId: 5,
+    contentTitle: 'Understanding Quantum Computing',
+    bookmarkId: 105,
+    bookmarkSentence:
+      'Quantum computing promises to revolutionize the field of computation.',
+    description: null,
+    timestamp: 1620504873,
   },
 ];
 
 export default function HighlighterAndMemo() {
+  const {
+    data: bookmarkDatas,
+    isLoading,
+    isError,
+    error,
+  } = useFetchBookmarks(1);
+
+  if (isLoading) {
+    return <p className="mt-8">로딩 중...</p>;
+  }
+
+  if (isError) {
+    return (
+      <p className="mt-8 text-red-500">에러가 발생했습니다: {error.message}</p>
+    );
+  }
+
+  if (!bookmarkDatas || bookmarkDatas.data.length === 0) {
+    return <p className="mt-8">북마크가 없습니다.</p>;
+  }
+
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-6">형광펜과 메모</h1>
-      <p className="text-sm text-muted-foreground">12개의 형광펜</p>
+      <p className="text-sm text-muted-foreground">
+        {bookmarkDatas.data.length}개의 형광펜
+      </p>
       {memoItems.map((item) => (
-        <MemoItem key={item.id} item={item} />
+        <MemoItem key={item.bookmarkId} data={item} />
       ))}
     </div>
   );

--- a/src/components/MemoItem.tsx
+++ b/src/components/MemoItem.tsx
@@ -3,29 +3,20 @@
 import Link from 'next/link';
 import { useState, useRef, useEffect } from 'react';
 import { Circle, Share2, Trash2 } from 'lucide-react';
-import { convertTimestampToDate } from '@/lib/convertTimestampToDate';
+import { Bookmark } from '@/types/Bookmark';
 import { Button } from './ui/button';
-
-interface MemoItemProps {
-  contentId: number;
-  contentTitle: string;
-  bookmarkId: number;
-  bookmarkSentence: string;
-  description: string | null;
-  timestamp: number;
-}
 
 export default function MemoItem({
   data: {
     contentId,
     contentTitle,
     bookmarkId,
-    bookmarkSentence,
+    bookmarkDetail,
     description,
-    timestamp,
+    updatedAt,
   },
 }: {
-  data: MemoItemProps;
+  data: Bookmark;
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [memo, setMemo] = useState<string | null>(description);
@@ -54,15 +45,13 @@ export default function MemoItem({
             {contentTitle}
           </h2>
         </Link>
-        <span className="text-xs text-muted-foreground">
-          {convertTimestampToDate(timestamp)}
-        </span>
+        <span className="text-xs text-muted-foreground">{updatedAt}</span>
       </div>
       {/* 북마크된 문장 */}
       <div className="flex items-start space-x-2 mb-2">
         <Circle className="h-3 w-3 mt-1 text-muted-foreground" />
         <p className="text-sm text-muted-foreground flex-grow">
-          {bookmarkSentence}
+          {bookmarkDetail}
         </p>
       </div>
 
@@ -83,7 +72,7 @@ export default function MemoItem({
             <Button variant="outline" onClick={() => {}}>
               취소
             </Button>
-            TODO(@smosco): 북마크 메모 수정 삭제 기능 api 연결
+            {/* TODO(@smosco): 북마크 메모 수정 삭제 기능 api 연결 */}
             <Button onClick={() => {}}>저장</Button>
           </div>
         )}

--- a/src/components/MemoItem.tsx
+++ b/src/components/MemoItem.tsx
@@ -1,37 +1,94 @@
+'use client';
+
 import Link from 'next/link';
+import { useState, useRef, useEffect } from 'react';
 import { Circle, Share2, Trash2 } from 'lucide-react';
+import { convertTimestampToDate } from '@/lib/convertTimestampToDate';
 import { Button } from './ui/button';
 
 interface MemoItemProps {
-  id: string;
-  title: string;
-  content: string;
-  timestamp: string;
-  description?: string;
+  contentId: number;
+  contentTitle: string;
+  bookmarkId: number;
+  bookmarkSentence: string;
+  description: string | null;
+  timestamp: number;
 }
 
-export default function MemoItem({ item }: { item: MemoItemProps }) {
+export default function MemoItem({
+  data: {
+    contentId,
+    contentTitle,
+    bookmarkId,
+    bookmarkSentence,
+    description,
+    timestamp,
+  },
+}: {
+  data: MemoItemProps;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [memo, setMemo] = useState<string | null>(description);
+  const memoRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (memoRef.current && !memoRef.current.contains(event.target as Node)) {
+        setIsEditing(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [memoRef]);
+
+  console.log(bookmarkId);
   return (
     <div className="py-4 border-b border-gray-200">
+      {/* 북마크된 문장이 포함된 콘텐츠 제목 */}
       <div className="flex items-center justify-between mb-2">
-        <Link href={`/learn/reading/detail/${item.id}`}>
+        <Link href={`/learn/reading/detail/${contentId}`}>
           <h2 className="text-sm font-medium hover:underline underline-offset-2">
-            {item.title}
+            {contentTitle}
           </h2>
         </Link>
-        <span className="text-xs text-muted-foreground">{item.timestamp}</span>
+        <span className="text-xs text-muted-foreground">
+          {convertTimestampToDate(timestamp)}
+        </span>
       </div>
+      {/* 북마크된 문장 */}
       <div className="flex items-start space-x-2 mb-2">
         <Circle className="h-3 w-3 mt-1 text-muted-foreground" />
         <p className="text-sm text-muted-foreground flex-grow">
-          {item.content}
+          {bookmarkSentence}
         </p>
       </div>
-      {item.description && (
-        <div className="ml-5 pl-4 border-l-2 border-purple-700">
-          <p className="text-sm text-muted-foreground">{item.description}</p>
-        </div>
-      )}
+
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div
+        ref={memoRef}
+        className={`flex ml-5 pl-4 border-l-2 ${isEditing ? 'border-purple-700' : 'border-gray-300'}`}
+        onClick={() => setIsEditing(true)}
+      >
+        <textarea
+          value={memo || ''}
+          onChange={(e) => setMemo(e.target.value)}
+          placeholder={memo || '메모를 입력해주세요.'}
+          className="min-h-6 w-[592px] border-none outline-none p-0 mr-6"
+        />
+        {isEditing && (
+          <div className="flex justify-end space-x-2">
+            <Button variant="outline" onClick={() => {}}>
+              취소
+            </Button>
+            TODO(@smosco): 북마크 메모 수정 삭제 기능 api 연결
+            <Button onClick={() => {}}>저장</Button>
+          </div>
+        )}
+      </div>
+      {/* 북마크 문장 삭제 공유 버튼 */}
       <div className="flex justify-end space-x-2 mt-2">
         <Button variant="ghost" size="icon" aria-label="Share">
           <Share2 className="h-4 w-4" />

--- a/src/lib/convertTimestampToDate.ts
+++ b/src/lib/convertTimestampToDate.ts
@@ -1,0 +1,7 @@
+export const convertTimestampToDate = (timestamp: number) => {
+  const date = new Date(timestamp * 1000);
+
+  const readableDate = date.toISOString().replace('T', ' ').substring(0, 19);
+
+  return readableDate;
+};

--- a/src/types/Bookmark.ts
+++ b/src/types/Bookmark.ts
@@ -1,13 +1,32 @@
-// src/types/Bookmark.ts
-export interface Bookmark {
+export interface BookmarkByContentId {
   bookmarkId: number;
   sentenceIndex: number;
   wordIndex?: number;
   description: string | null;
 }
 
-export interface BookmarkResponse {
+export interface BookmarkByContentIdResponse {
   code: string;
   message: string;
-  data: Bookmark[];
+  data: {
+    bookmarkList: BookmarkByContentId[];
+  };
+}
+
+export interface Bookmark {
+  bookmarkId: number;
+  bookmarkDetail: string | null;
+  description: string | null;
+  contentId: number;
+  contentTitle: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BookmarkListResponse {
+  code: string;
+  message: string;
+  data: {
+    bookmarkMyList: Bookmark[];
+  };
 }

--- a/src/types/Preview.ts
+++ b/src/types/Preview.ts
@@ -7,10 +7,16 @@ export interface Preview {
   hits: number;
 }
 
-export interface PreviewResponse {
+export interface ReadingPreviewResponse {
   code: string;
   message: string;
-  data: Preview[];
+  data: { readingPreview: Preview[] };
+}
+
+export interface ListeningPreviewResponse {
+  code: string;
+  message: string;
+  data: { listeningPreview: Preview[] };
 }
 
 export type ContentsResponse = {

--- a/src/types/Scrap.ts
+++ b/src/types/Scrap.ts
@@ -1,0 +1,26 @@
+// src/types/Scrap.ts
+export interface ScrapListItem {
+  scrapId: number;
+  contentId: number;
+}
+
+export interface FetchScrapResponse {
+  code: string;
+  message: string;
+  data: {
+    scrapList: ScrapListItem[];
+  };
+}
+
+export interface CreateScrapResponse {
+  code: string;
+  message: string;
+  data: {
+    contentId: number;
+  };
+}
+
+export interface DeleteScrapResponse {
+  code: string;
+  message: string;
+}


### PR DESCRIPTION
### 📄 Description of the PR

- **기능 설명**: 스크랩 페이지의 북마크 수정 및 삭제 기능을 구현했어요 모든 북마크 불러오는 API 함수와 훅을 추가하여 기능을 확장했습니다.

- **Close**: #81 

### 🔧 What has been changed?

- 스크랩 페이지에서 북마크 수정 및 삭제 기능 구현
- 모든 북마크를 불러오는 API 함수 및 관련 훅 추가
- 스크랩 생성, 조회, 삭제 API 요청 함수 및 훅 구현
- 변경된 preview 데이터 타입 수정

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

- 현재 스크랩은 요청 훅만 구현해 놓은 상태입니다. 스크랩은 다음 이슈에서 구현하겠습니다!
- 리딩/리스닝 필터 컴포넌트도 레이아웃에서 아직 옮기지 못했습니다.

### ✅ Checklist

- [ ] UI 브랜치와 함께 기능 동작 여부 확인
- [ ] 함수 이름, 변수 이름이 선언적이고 코드의 기능을 명확하게 설명하는지 확인
