### PR TITLE
feat : 스크랩 콘텐츠 타입에 따라 배지로 구분

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,10 @@ const nextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'i.ytimg.com',
+      },
+      {
+        protocol: 'https',
         hostname: 'avatar.iran.liara.run',
       },
     ],

--- a/src/app/scrapbook/content/page.tsx
+++ b/src/app/scrapbook/content/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import ArticlePreview from '@/components/ArticlePreview';
 import { useFetchScrap } from '@/api/hooks/useScrap';
+import ContentPreview from '@/components/ContentPreview';
 
 export default function RecentContent() {
   const { data: allScrapData, isLoading, isError, error } = useFetchScrap();
@@ -22,13 +22,9 @@ export default function RecentContent() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-6">최근 스크랩한 콘텐츠</h1>
-      {allScrapData.data.scrapList.map((item) =>
-        item.contentType === 'READING' ? (
-          <ArticlePreview key={item.scrapId} data={item} />
-        ) : (
-          '리스닝 프리뷰를 리턴합니다.'
-        ),
-      )}
+      {allScrapData.data.scrapList.map((item) => (
+        <ContentPreview key={item.scrapId} data={item} />
+      ))}
     </div>
   );
 }

--- a/src/components/ContentPreview.tsx
+++ b/src/components/ContentPreview.tsx
@@ -1,0 +1,92 @@
+import Link from 'next/link';
+import { formatDate } from '@/lib/formatDate';
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { BookOpen, Headphones, Eye } from 'lucide-react';
+
+interface ContentPreviewData {
+  scrapId?: number;
+  contentId: number;
+  title: string;
+  category?: string;
+  thumbnailUrl: string;
+  preScripts: string;
+  hits?: number;
+  createdAt?: string;
+  contentType: 'READING' | 'LISTENING';
+}
+
+export default function ContentPreview({
+  data: {
+    contentId,
+    thumbnailUrl,
+    title,
+    category,
+    preScripts,
+    hits,
+    createdAt,
+    contentType,
+  },
+}: {
+  data: ContentPreviewData;
+}) {
+  const isReading = contentType === 'READING';
+  const Icon = isReading ? BookOpen : Headphones;
+  const accentColor = isReading ? 'bg-green-300' : 'bg-indigo-200';
+  const linkHref = isReading
+    ? `/learn/reading/detail/${contentId}`
+    : `/learn/listening/detail/${contentId}`;
+
+  return (
+    <Link href={linkHref}>
+      <Card className="mb-4 hover:shadow-md transition-shadow duration-200">
+        <CardContent className="p-4">
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="md:w-1/4 flex-shrink-0">
+              <div className="aspect-video md:aspect-square w-full">
+                <img
+                  src={thumbnailUrl}
+                  alt={title}
+                  className="rounded-sm object-cover h-full"
+                />
+              </div>
+            </div>
+            <div className="flex-1">
+              <div className="flex flex-start justify-between mb-2">
+                <Badge
+                  variant="secondary"
+                  className={`${accentColor} text-gray-800`}
+                >
+                  <Icon className="w-4 h-4 mr-1" />
+                  {contentType}
+                </Badge>
+                {createdAt && (
+                  <span className="text-sm text-muted-foreground">
+                    {formatDate(createdAt)} 저장
+                  </span>
+                )}
+              </div>
+              <h2 className="text-lg font-semibold mb-2 hover:underline underline-offset-2">
+                {title}
+              </h2>
+              {category && <p className="text-sm mb-2">{category}</p>}
+              <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                {preScripts}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter className="px-4 py-2 flex justify-between items-center ">
+          <div className="flex items-center">
+            {hits !== undefined && (
+              <span className="flex items-center mr-4">
+                <Eye className="w-4 h-4 mr-1" />
+                {hits}회
+              </span>
+            )}
+          </div>
+        </CardFooter>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/FloatingButtons.tsx
+++ b/src/components/FloatingButtons.tsx
@@ -12,22 +12,24 @@ export default function FloatingButtons({
 }: {
   isScrapped: boolean | undefined;
   onScrapToggle: () => void;
-  showTranslate: boolean;
-  onTranslateToggle: () => void;
+  showTranslate?: boolean;
+  onTranslateToggle?: () => void;
 }) {
   return (
     <div className="fixed left-4 top-1/2 -translate-y-1/2 flex flex-col gap-4">
-      <Button
-        variant="outline"
-        size="icon"
-        className={`rounded-full w-12 h-12 ${showTranslate && 'bg-primary'}`}
-        onClick={onTranslateToggle}
-      >
-        <Languages
-          className="h-6 w-6"
-          color={showTranslate ? 'white' : 'black'}
-        />
-      </Button>
+      {showTranslate && onTranslateToggle && (
+        <Button
+          variant="outline"
+          size="icon"
+          className={`rounded-full w-12 h-12 ${showTranslate && 'bg-primary'}`}
+          onClick={onTranslateToggle}
+        >
+          <Languages
+            className="h-6 w-6"
+            color={showTranslate ? 'white' : 'black'}
+          />
+        </Button>
+      )}
       <Button
         variant="outline"
         size="icon"


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 스크랩 페이지에서 스크랩한 콘텐츠를 콘텐츠 타입에 따라 배지로 구분했습니다.
- Close #94 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- 리스닝 페이지 스크랩 기능을 추가했습니다.
- 스크랩 페이지에서 리딩과 리스닝 콘텐츠를 다른 컴포넌트로 보여주려고 했는데 통일성이 깨지는 것 같아서 contentPreview라는 컴포넌트로 보여주되 배지로만 구분했습니다.

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/13e75a03-6f97-4c55-9ccd-c243887137d7)

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
