### PR TITLE
feat : 로그인 여부에 따라 로그인,로그아웃 버튼 보여주기

### DIFF
--- a/src/api/hooks/useUserInfo.ts
+++ b/src/api/hooks/useUserInfo.ts
@@ -3,6 +3,8 @@ import {
   UserUpdateResponse,
   UserUpdateRequest,
   UserTimeResponse,
+  UserLoginStatusResponse,
+  UserRequestLogoutResponse,
 } from '@/types/User';
 import {
   useQuery,
@@ -14,6 +16,8 @@ import {
   fetchUserInfo,
   updateUserInfo,
   fetchUserTime,
+  fetchUserLoginStatus,
+  fetchUserLogout,
 } from '@/api/queries/userQueries';
 
 export const useUserInfo = (): UseQueryResult<UserResponse> => {
@@ -38,5 +42,25 @@ export const useUserTime = (): UseQueryResult<UserTimeResponse> => {
   return useQuery({
     queryKey: ['userTime'],
     queryFn: () => fetchUserTime(),
+  });
+};
+
+// 로그인 상태 확인하는 tanstack query훅.
+export const useUserLoginStatus =
+  (): UseQueryResult<UserLoginStatusResponse> => {
+    return useQuery<UserLoginStatusResponse>({
+      queryKey: ['loginStatus'],
+      queryFn: fetchUserLoginStatus,
+    });
+  };
+
+export const useRequestLogout = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<UserRequestLogoutResponse, Error>({
+    mutationFn: () => fetchUserLogout(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['loginStatus'] });
+    },
   });
 };

--- a/src/api/queries/userQueries.ts
+++ b/src/api/queries/userQueries.ts
@@ -3,6 +3,7 @@ import {
   UserUpdateRequest,
   UserUpdateResponse,
   UserTimeResponse,
+  UserLoginStatusResponse,
 } from '@/types/User';
 
 const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api`;
@@ -53,6 +54,35 @@ export const fetchUserTime = async (): Promise<UserTimeResponse> => {
     headers: {
       'Content-Type': 'application/json',
     },
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+export const fetchUserLoginStatus =
+  async (): Promise<UserLoginStatusResponse> => {
+    const response = await fetch(`${BASE_URL}/user/status`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  };
+
+export const fetchUserLogout = async (): Promise<UserLoginStatusResponse> => {
+  const response = await fetch(`${BASE_URL}/user/logout`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
   });
   if (!response.ok) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import './globals.css';
 import { Header } from '@/components/layout/Header';
 import { MobileNav } from '@/components/layout/MobileNav';
 import ContentInner from '@/components/layout/ContentInner';
-import Providers from '@/providers/Providers';
+import QueryClientProvider from '@/providers/QueryClientProvider';
 
 const pretendard = localFont({
   src: './fonts/PretendardVariable.woff2',
@@ -24,11 +24,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${pretendard.variable} antialiased`}>
-        <Providers>
+        <QueryClientProvider>
           <Header />
           <ContentInner>{children}</ContentInner>
           <MobileNav />
-        </Providers>
+        </QueryClientProvider>
       </body>
     </html>
   );

--- a/src/components/LogInOutButton.tsx
+++ b/src/components/LogInOutButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { useUserLoginStatus } from '@/api/hooks/useUserInfo'; // custom hook import
+import { useRequestLogout } from '@/api/hooks/useUserInfo'; // custom hook import
+
+export default function LogInOutButton() {
+  const { data: isLogin } = useUserLoginStatus();
+  const { mutate: fetchUserLogout } = useRequestLogout();
+
+  return isLogin?.data ? (
+    <Button onClick={() => fetchUserLogout()}>로그아웃</Button>
+  ) : (
+    <Link href="/login">
+      <Button>로그인</Button>
+    </Link>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import {
   CircleUserRound,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import LogInOutButton from '@/components/LogInOutButton';
 
 export const navItems = [
   { name: '학습', href: '/learn/listening', icon: BookHeadphones },
@@ -20,7 +21,6 @@ export const navItems = [
 
 export function Header() {
   const pathname = usePathname();
-
   return (
     <div className="sticky top-0 z-50 bg-[rgba(255,255,255,0.95)] border-b">
       <header className="flex items-center max-w-[1440px] h-16 mx-auto px-6">
@@ -46,9 +46,7 @@ export function Header() {
           <Button variant="ghost" size="icon">
             <Bell className="h-5 w-5" />
           </Button>
-          <Button variant="default" className="hidden md:inline-flex ml-4">
-            로그아웃
-          </Button>
+          <LogInOutButton />
         </div>
       </header>
     </div>

--- a/src/providers/QueryClientProvider.tsx
+++ b/src/providers/QueryClientProvider.tsx
@@ -25,7 +25,11 @@ function getQueryClient() {
   return browserQueryClient;
 }
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function TanstackQueryPovider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const queryClient = getQueryClient();
 
   return (

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -37,3 +37,14 @@ export interface UserTimeResponse {
     updatedAt: 'string';
   };
 }
+
+export interface UserLoginStatusResponse {
+  code: string;
+  message: string;
+  data: boolean; // 로그인 상태
+}
+
+export interface UserRequestLogoutResponse {
+  code: string;
+  message: string;
+}


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 로그인 여부에 따라 로그인,로그아웃 버튼 보여주기
- Close #100 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- rename : provider -> QueryClientProvider로 이름을 바꾸었습니다.
-> 원래는 authoprovider를 사용할 예정이라 각각의 provider컴포넌트로 만들기 위해 rename을 했지만 결과적으로는 authoprovider를 사용하지 않아  QueryClientProvider만 rename을 하게 되었습니다.

- 로그인 로직에 따라 로그인, 로그아웃 버튼 보여주는 로직을 구현하였습니다
-> 전역관리상태라이브러리 없이, tanstack query자체로 구현이 가능합니다. 
->  tanstack query에는 처음 fetch해온 데이터가 변경되지 않는 한 캐시 상태로 저장해두기 때문에 전역관리상태라이브러리가 필요하지 않습니다.
이 캐시 데이터가 변할 때만 api호출을 하기 때문에 api해온 데이터가 브라우저를 새로고침하면 날라갈까 걱정할 필요도 없습니다.  

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/b34675ba-c7d4-4535-8dc8-7f4c516ba28e)
![image](https://github.com/user-attachments/assets/c9c07a6e-9a7d-466b-ada7-1d911b72a888)
로그인을 하면 쿠키에 토큰이 있고, 로그아웃을 하면 토큰이 사라집니다. 
### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
