### PR TITLE
feat : 영상과 자막, 북마크의 싱크 더 자세히 맞추는 함수 구현

### DIFF
--- a/src/components/BookmarkMemoItem.tsx
+++ b/src/components/BookmarkMemoItem.tsx
@@ -71,7 +71,11 @@ export default function BookmarkMemoItem({
           <Button
             variant="secondary"
             className="rounded-full h-6 px-3"
-            onClick={() => seekTo(subtitle?.startTimeInSecond as number)}
+            onClick={() =>
+              // TODO(@smosco): 북마크 메모 싱크
+              // 자막 시작시간으로 이동했을 때 이전 자막을 보여주는 문제 해결을 위해 0.1초 보정
+              seekTo((subtitle?.startTimeInSecond as number) + 0.1)
+            }
           >
             {convertTime(subtitle?.startTimeInSecond as number)}
           </Button>

--- a/src/components/ReactScriptPlayer/LineView.tsx
+++ b/src/components/ReactScriptPlayer/LineView.tsx
@@ -12,7 +12,6 @@ interface LineViewProps {
   currentSubtitleIndex: number;
   seekTo: (timeInSeconds: number) => void;
   onSelectWord: (word: string, subtitle: Subtitle, index: number) => void;
-  isVideoReadyButIsNotPlayingYet: boolean;
   bookmarkedIndices: number[];
 }
 
@@ -22,7 +21,6 @@ export function LineView({
   currentSubtitleIndex,
   seekTo,
   onSelectWord,
-  isVideoReadyButIsNotPlayingYet,
   bookmarkedIndices,
 }: LineViewProps) {
   const totalSubtitles = subtitles.length;
@@ -50,26 +48,22 @@ export function LineView({
         </button>
       </div>
       {/* 비디오가 첫 로딩 후 재생되지 않았을 때만 준비 메세지 보여줌 */}
-      {isVideoReadyButIsNotPlayingYet ? (
-        <h2>영상을 재생해주세요!</h2>
-      ) : (
-        subtitles[currentSubtitleIndex] && (
-          // TODO: 사용자가 자막이 언제 넘어갈지 알 수 있도록 progressbar 추가
 
-          <div
-            className={`transition-colors duration-300 ${
-              bookmarkedIndices.includes(currentSubtitleIndex)
-                ? 'bg-yellow-200' // 북마크된 자막 하이라이트
-                : ''
-            }`}
-          >
-            <TextDisplay
-              subtitle={subtitles[currentSubtitleIndex]}
-              selectedLanguages={selectedLanguages}
-              onSelectWord={onSelectWord}
-            />
-          </div>
-        )
+      {subtitles[currentSubtitleIndex] && (
+        // TODO: 사용자가 자막이 언제 넘어갈지 알 수 있도록 progressbar 추가
+        <div
+          className={`transition-colors duration-300 ${
+            bookmarkedIndices.includes(currentSubtitleIndex)
+              ? 'bg-yellow-200' // 북마크된 자막 하이라이트
+              : ''
+          }`}
+        >
+          <TextDisplay
+            subtitle={subtitles[currentSubtitleIndex]}
+            selectedLanguages={selectedLanguages}
+            onSelectWord={onSelectWord}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/ReactScriptPlayer/index.tsx
+++ b/src/components/ReactScriptPlayer/index.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React from 'react';
+import { findCurrentSubtitleIndex } from '@/lib/findCurrentSubtitleIndex';
+import { Script } from '@/types/ContentDetail';
 import { LanguageCode, Subtitle } from '../../types/Scripts';
 import { LineView } from './LineView';
 import { BlockView } from './BlockView';
 
 export interface ReactScriptPlayerProps {
   mode: 'line' | 'block';
-  subtitles: Subtitle[];
+  subtitles: Script[];
   selectedLanguages: LanguageCode[];
   seekTo: (timeInSeconds: number) => void;
   currentTime: number;
@@ -28,17 +30,8 @@ export function ReactScriptPlayer({
   isVideoReadyButIsNotPlayingYet,
   bookmarkedIndices,
 }: ReactScriptPlayerProps) {
-  const reversedSubtitles = useMemo(
-    () => [...subtitles].reverse(),
-    [subtitles],
-  );
-  // TODO(@smosco): 현재 자막 인덱스 찾는 로직 리팩토링
-  const currentSubtitleIndex = useMemo(() => {
-    const index = reversedSubtitles.findIndex(
-      (subtitle) => subtitle.startTimeInSecond < currentTime,
-    );
-    return reversedSubtitles.length - 1 - index;
-  }, [reversedSubtitles, currentTime]);
+  const currentSubtitleIndex =
+    findCurrentSubtitleIndex(subtitles, currentTime) ?? 0;
 
   return (
     <div className="flex flex-col h-[16rem] p-6 border-2 border-violet-100 rounded-xl overflow-y-auto">

--- a/src/components/ReactScriptPlayer/index.tsx
+++ b/src/components/ReactScriptPlayer/index.tsx
@@ -15,7 +15,6 @@ export interface ReactScriptPlayerProps {
   currentTime: number;
   onClickSubtitle: (subtitle: Subtitle, index: number) => void;
   onSelectWord: (word: string, subtitle: Subtitle, index: number) => void;
-  isVideoReadyButIsNotPlayingYet: boolean;
   bookmarkedIndices: number[];
 }
 
@@ -27,7 +26,6 @@ export function ReactScriptPlayer({
   currentTime,
   onClickSubtitle,
   onSelectWord,
-  isVideoReadyButIsNotPlayingYet,
   bookmarkedIndices,
 }: ReactScriptPlayerProps) {
   const currentSubtitleIndex =
@@ -46,7 +44,6 @@ export function ReactScriptPlayer({
             selectedLanguages={selectedLanguages}
             seekTo={seekTo}
             onSelectWord={onSelectWord}
-            isVideoReadyButIsNotPlayingYet={isVideoReadyButIsNotPlayingYet}
             bookmarkedIndices={bookmarkedIndices}
           />
         )}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/api/hooks/useBookmarks';
 import { Check, X, BookmarkPlus, MessageSquarePlus } from 'lucide-react';
 import { convertTime } from '@/lib/convertTime';
+import { findCurrentSubtitleIndex } from '@/lib/findCurrentSubtitleIndex';
 import ControlBar from './ControlBar';
 import SubtitleOption from './SubtitleOption';
 import { ReactScriptPlayer } from './ReactScriptPlayer';
@@ -106,12 +107,8 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
     setIsVideoReadyButIsNotPlayingYet(true);
   };
 
-  // Find the current subtitle index based on the current video time
-  const currentSubtitleIndex = scriptsData?.findIndex(
-    (subtitle) =>
-      subtitle.startTimeInSecond <= currentTime &&
-      subtitle.startTimeInSecond + subtitle.durationInSecond >= currentTime,
-  );
+  const currentSubtitleIndex =
+    findCurrentSubtitleIndex(scriptsData, currentTime) ?? 0;
 
   const handleBookmark = () => {
     if (currentSubtitleIndex !== null && currentSubtitleIndex !== undefined) {
@@ -122,7 +119,16 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
   };
 
   const handleMemo = () => {
-    if (currentSubtitleIndex !== null && currentSubtitleIndex !== undefined) {
+    if (
+      scriptsData &&
+      currentSubtitleIndex !== null &&
+      currentSubtitleIndex !== undefined
+    ) {
+      console.log(
+        'bookmarkmemoitem',
+        currentSubtitleIndex,
+        scriptsData[currentSubtitleIndex].enScript,
+      );
       setSelectedSentenceIndex(currentSubtitleIndex);
       setNewNoteText('');
       setIsAddingNote(true);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -43,8 +43,6 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
     useState<LanguageCode[]>(availableLanguages);
   const [currentTime, setCurrentTime] = useState(0);
   const [mounted, setMounted] = useState(false); // 추가: 마운트 상태 확인
-  const [isVideoReadyButIsNotPlayingYet, setIsVideoReadyButIsNotPlayingYet] =
-    useState(true); //  준비 메세지 상태 관리
   const [isPlaying, setIsPlaying] = useState(false);
   const [volume, setVolume] = useState(0.5);
   const [playbackRate, setPlayBackRate] = useState(1);
@@ -100,11 +98,6 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
     isPlaying,
     volume,
     setPlayBackRate,
-  };
-
-  const handleVideoReady = () => {
-    // 처음 비디오가 준비되었을 때만 true로 설정
-    setIsVideoReadyButIsNotPlayingYet(true);
   };
 
   const currentSubtitleIndex =
@@ -167,11 +160,7 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
               playing={isPlaying}
               width="100%"
               height="100%"
-              onReady={handleVideoReady}
-              onPlay={() => {
-                setIsPlaying(true);
-                setIsVideoReadyButIsNotPlayingYet(false);
-              }}
+              onPlay={() => setIsPlaying(true)}
               onStart={() => setIsPlaying(true)}
               onPause={() => setIsPlaying(false)}
               onProgress={handleProgress}
@@ -208,7 +197,6 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
           onSelectWord={(word, subtitle, index) => {
             console.log(word, subtitle, index);
           }}
-          isVideoReadyButIsNotPlayingYet={isVideoReadyButIsNotPlayingYet} // video첫로딩후재생버튼누르기전에는 영상을 재생해주세요 메시지 보여줌
           bookmarkedIndices={
             bookmarkData && bookmarkData?.data.bookmarkList.length > 0
               ? bookmarkData.data.bookmarkList.map(

--- a/src/lib/findCurrentSubtitleIndex.ts
+++ b/src/lib/findCurrentSubtitleIndex.ts
@@ -1,0 +1,34 @@
+import { Script } from '@/types/ContentDetail';
+
+export const findCurrentSubtitleIndex = (
+  subtitles: Script[] | undefined,
+  currentTime: number,
+  adjustmentTime: number = 0.05, // 자막을 약간 일찍 표시
+  extendedTime: number = 0.05, // 자막을 약간 늦게 종료
+): number | null => {
+  if (!subtitles || subtitles.length === 0) return null;
+
+  const middleIndex = Math.floor(subtitles.length / 2);
+
+  if (currentTime < subtitles[middleIndex].startTimeInSecond) {
+    // 앞부분 자막 탐색 (순차적으로)
+    const index = subtitles.findIndex(
+      (subtitle) =>
+        subtitle.startTimeInSecond - adjustmentTime <= currentTime &&
+        subtitle.startTimeInSecond + subtitle.durationInSecond + extendedTime >=
+          currentTime,
+    );
+    return index !== -1 ? index : null;
+  }
+  // 뒷부분 자막 탐색 (뒤에서부터)
+  const reversedSubtitles = [...subtitles].reverse();
+  const index = reversedSubtitles.findIndex(
+    (subtitle) =>
+      subtitle.startTimeInSecond - adjustmentTime <= currentTime &&
+      subtitle.startTimeInSecond + subtitle.durationInSecond + extendedTime >=
+        currentTime,
+  );
+  return index !== -1
+    ? subtitles.length - 1 - index // 원래 배열 기준 인덱스 반환
+    : null;
+};


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 영상과 자막의 싱크를 좀 더 섬세하게 맞출 수 있는 함수를 구현했습니다.
- Close #110 

### 🔧 What has been changed?
- 영상과 자막의 싱크를 좀 더 섬세하게 맞출 수 있는 함수를 구현
- 자막의 시작 시간을 현재 시간보다 약간 앞서 표시하거나, 끝나는 시간을 약간 늦춰 자막이 영상과 더 자연스럽게 동기화
- 영상 중반 이전까지는 현재 자막 인덱스를 처음부터 찾고 중간 이상부터는 뒤에서부터 찾도록 수정
- 메모와의 싱크가 안 맞아서 메모 시간 클릭하면 0.1초 뒤로 영상 시간 이동시키니까 좀 더 잘 맞음
- 리스닝 페이지 처음 접속시 영상 재생 안되었을 때 0번째 자막을 보여주는 걸로 대체

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
- 앞뒤로 얼마나 더 보여줄지는 findCurrentSubtitleIndex 함수에서 수정하면 됩니다.

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
