### PR TITLE
feat : 캐러셀 컴포넌트 크기 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function HomePage() {
           </div>
         }
         itemComponent={ReadingPreviewCard}
-        itemWidth={320}
+        itemWidth={280}
         itemsPerPage={3}
       />
       {/* 인기 리딩 컨텐츠 캐러셀 */}
@@ -52,7 +52,7 @@ export default function HomePage() {
           </div>
         }
         itemComponent={ListeningPreviewCard}
-        itemWidth={320}
+        itemWidth={280}
         itemsPerPage={3}
       />
     </div>

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -14,19 +14,19 @@ interface CarouselProps<T> {
     onNext?: () => void;
   }) => JSX.Element;
   previewDatas: T[]; // TODO(@smosco): data 타입 정의
-  itemWidth?: number;
-  itemsPerPage?: number;
+  itemWidth: number;
+  itemsPerPage: number;
 }
 
-const DEFAULT_ITEM_WIDTH = 320;
-const DEFAULT_ITEMS_PER_PAGE = 3;
+// const DEFAULT_ITEM_WIDTH = 300;
+// const DEFAULT_ITEMS_PER_PAGE = 3;
 
 export default function Carousel<T>({
   header,
   itemComponent,
   previewDatas,
-  itemWidth = DEFAULT_ITEM_WIDTH,
-  itemsPerPage = DEFAULT_ITEMS_PER_PAGE,
+  itemWidth,
+  itemsPerPage,
 }: CarouselProps<T>) {
   // 리액트가 컴포넌트로 인지하도록 대문자로 시작하도록 변경
   const ItemComponent = itemComponent;

--- a/src/components/ListeningPreviewCard.tsx
+++ b/src/components/ListeningPreviewCard.tsx
@@ -14,10 +14,13 @@ export default function ListeningPreviewCard({
   data: Preview;
 }) {
   return (
-    <Link href={`/learn/listening/detail/${contentId}`} className="mr-3">
-      <Card className="w-full max-w-xs overflow-hidden rounded-lg hover:shadow-card-hover">
+    <Link
+      href={`/learn/listening/detail/${contentId}`}
+      className="w-full h-fit mr-3"
+    >
+      <Card className="max-w-xs overflow-hidden rounded-lg hover:shadow-card-hover">
         <CardContent className="p-0">
-          <div className="relative w-full h-44">
+          <div className="relative w-full h-40">
             <img
               src={thumbnailUrl}
               alt={title}
@@ -30,7 +33,7 @@ export default function ListeningPreviewCard({
           </div>
         </CardContent>
       </Card>
-      <div className="mt-2">
+      <div className="mt-2 space-y-2">
         <Badge>{category}</Badge>
         <h3 className="font-bold line-clamp-2 break-words hover:underline underline-offset-2">
           {title}

--- a/src/components/ReadingPreviewCard.tsx
+++ b/src/components/ReadingPreviewCard.tsx
@@ -14,10 +14,13 @@ export default function ReadingPreviewCard({
   data: Preview;
 }) {
   return (
-    <Link href={`/learn/reading/detail/${contentId}`}>
-      <Card className="overflow-hidden shadow-card hover:shadow-card-hover hover:border-border w-80 h-80 mr-3">
+    <Link
+      href={`/learn/reading/detail/${contentId}`}
+      className="w-full h-fit mr-3"
+    >
+      <Card className="overflow-hidden shadow-card hover:shadow-card-hover hover:border-border">
         <CardContent className="p-0 h-full">
-          <div className="relative w-full h-40 rounded-t-lg overflow-hidden">
+          <div className="relative w-full h-40 overflow-hidden">
             <Image
               src={thumbnailUrl}
               alt={title}

--- a/src/components/quiz/BlankQuiz.tsx
+++ b/src/components/quiz/BlankQuiz.tsx
@@ -25,7 +25,7 @@ export function BlankQuiz({
   }, [userInput, answer, onSubmit]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-1 flex-col gap-6">
       <p>{questionKo}</p>
       <div className="inline whitespace-pre-wrap">
         <span>{questionParts[0]}</span>

--- a/src/components/quiz/OrderQuiz.tsx
+++ b/src/components/quiz/OrderQuiz.tsx
@@ -43,9 +43,9 @@ export default function OrderQuiz({
   }, [selectedWords, answer, onSubmit]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-1 flex-col gap-6">
       <p>{questionKo}</p>
-      {/* Selected words */}
+      {/* 선택된 단어 */}
       <div className="flex flex-wrap gap-2 border-b min-h-8">
         {selectedWords.map((word, index) => (
           <Button
@@ -59,7 +59,7 @@ export default function OrderQuiz({
           </Button>
         ))}
       </div>
-      {/* Remaining words */}
+      {/* 남은 단어 */}
       <div className="flex flex-wrap gap-2">
         {remainingWords.map((word, index) => (
           <Button

--- a/src/components/quiz/Quiz.tsx
+++ b/src/components/quiz/Quiz.tsx
@@ -23,7 +23,7 @@ export default function Quiz({ data, onNext }: QuizProps) {
   };
 
   return (
-    <div className="flex flex-col gap-4 w-full p-10 border h-100">
+    <div className="flex flex-col gap-4 w-full p-10 border h-90">
       {data.type === 'BLANK' ? (
         <BlankQuiz
           questionKo={data.questionKo}

--- a/src/components/quiz/QuizCarousel.tsx
+++ b/src/components/quiz/QuizCarousel.tsx
@@ -14,7 +14,7 @@ export default function QuizCarousel({ quizListData }: QuizCarouselProps) {
       <Carousel
         previewDatas={quizListData}
         itemComponent={Quiz}
-        itemWidth={744}
+        itemWidth={800}
         itemsPerPage={1}
       />
     </div>


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 캐러셀 컴포넌트의 크기를 수정했습니다.
- Close #93 

### 🔧 What has been changed?

- 캐러셀 컴포넌트에서 줬던 defualt itemWidth, itemsPerpage를 없애고 props로 받는대로 만들어지게 만들었습니다.
- 퀴즈 캐러셀 크기 수정
<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/d189f887-2ba1-47f7-b1e9-996586fd9346)

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
