### PR TITLE
feat : 로그인여부에 따라 다른 퀴즈 커버 보여주기

### DIFF
--- a/src/app/learn/listening/detail/[id]/page.tsx
+++ b/src/app/learn/listening/detail/[id]/page.tsx
@@ -39,6 +39,7 @@ export default function DetailListeningPage() {
   const createScrapMutation = useCreateScrap(contentId);
   const deleteScrapMutation = useDeleteScrap(contentId);
 
+  const [showQuiz, setShowQuiz] = useState(false); // 퀴즈 풀기 버튼 누를 때 보여줌
   const { data: quizData } = useFetchQuiz(contentId);
 
   const [isScrapped, setIsScrapped] = useState<boolean | undefined>(undefined);
@@ -104,8 +105,50 @@ export default function DetailListeningPage() {
         scriptsData={ListeningDetailData?.data.scriptList}
       />
 
-      {quizData && (
-        <QuizCarousel quizListData={quizData.data['question-answer']} />
+      {/* 퀴즈 */}
+      {isLogin ? (
+        // 로그인 했을 때 퀴즈커버
+        <div className="relative w-full h-[400px] overflow-hidden rounded-lg shadow-lg ">
+          {!showQuiz && (
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-purple-600 flex flex-col items-center justify-center text-white p-8 transition-opacity duration-500 opacity-100 z-10">
+              <h2 className="text-3xl font-bold text-center mb-8">
+                방금 학습한 내용, 확실히 기억하고 있나요?
+                <br />
+                퀴즈로 점검해보세요!
+              </h2>
+              <Button
+                onClick={() => setShowQuiz(true)}
+                className="bg-white text-blue-600 hover:bg-blue-100 transition-colors duration-200"
+              >
+                퀴즈 풀기
+              </Button>
+            </div>
+          )}
+
+          {showQuiz && (
+            <div className="absolute inset-0 bg-white flex">
+              {/* 퀴즈 */}
+              {quizData && (
+                <QuizCarousel quizListData={quizData.data['question-answer']} />
+              )}
+            </div>
+          )}
+        </div>
+      ) : (
+        // 로그인안했을때 퀴즈 커버
+        <div className="relative w-full h-[400px] overflow-hidden rounded-lg shadow-lg">
+          <div className="absolute inset-0 bg-gradient-to-br from-purple-500 to-purple-700 flex flex-col items-center justify-center text-white p-8 transition-opacity duration-500 opacity-100">
+            <h2 className="text-3xl font-bold text-center mb-8">
+              퀴즈를 풀려면 로그인을 하세요
+            </h2>
+            <Button
+              className="bg-white text-purple-600 hover:bg-purple-100 transition-colors duration-200"
+              onClick={() => router.push('/login')}
+            >
+              로그인하기
+            </Button>
+          </div>
+        </div>
       )}
 
       {/* 로그인 모달 */}

--- a/src/app/learn/reading/detail/[id]/page.tsx
+++ b/src/app/learn/reading/detail/[id]/page.tsx
@@ -71,6 +71,8 @@ export default function DetailReadingPage() {
 
   const [isScrapped, setIsScrapped] = useState<boolean | undefined>(undefined);
 
+  const [showQuiz, setShowQuiz] = useState(false); // 퀴즈 풀기 버튼 누를 때 보여줌
+
   useEffect(() => {
     if (checkScrap?.data) {
       setIsScrapped(checkScrap.data); // 서버에서 스크랩 여부를 받아와 상태 업데이트
@@ -380,8 +382,52 @@ export default function DetailReadingPage() {
               />
             )}
           </div>
-          {quizData && (
-            <QuizCarousel quizListData={quizData.data['question-answer']} />
+          {/* 퀴즈 */}
+          {isLogin ? (
+            // 로그인 했을 때 퀴즈커버
+            <div className="relative w-full h-[400px] overflow-hidden rounded-lg shadow-lg ">
+              {!showQuiz && (
+                <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-purple-600 flex flex-col items-center justify-center text-white p-8 transition-opacity duration-500 opacity-100 z-10">
+                  <h2 className="text-3xl font-bold text-center mb-8">
+                    방금 학습한 내용, 확실히 기억하고 있나요?
+                    <br />
+                    퀴즈로 점검해보세요!
+                  </h2>
+                  <Button
+                    onClick={() => setShowQuiz(true)}
+                    className="bg-white text-blue-600 hover:bg-blue-100 transition-colors duration-200"
+                  >
+                    퀴즈 풀기
+                  </Button>
+                </div>
+              )}
+
+              {showQuiz && (
+                <div className="absolute inset-0 bg-white flex">
+                  {/* 퀴즈 */}
+                  {quizData && (
+                    <QuizCarousel
+                      quizListData={quizData.data['question-answer']}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          ) : (
+            // 로그인안했을때 퀴즈 커버
+            <div className="relative w-full h-[400px] overflow-hidden rounded-lg shadow-lg">
+              <div className="absolute inset-0 bg-gradient-to-br from-purple-500 to-purple-700 flex flex-col items-center justify-center text-white p-8 transition-opacity duration-500 opacity-100">
+                <h2 className="text-3xl font-bold text-center mb-8">
+                  퀴즈를 풀려면 로그인을 하세요
+                </h2>
+                <Button
+                  className="bg-white text-purple-600 hover:bg-purple-100 transition-colors duration-200"
+                  onClick={() => router.push('/login')}
+                >
+                  로그인하기
+                </Button>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/quiz/QuizCarousel.tsx
+++ b/src/components/quiz/QuizCarousel.tsx
@@ -10,7 +10,6 @@ interface QuizCarouselProps {
 export default function QuizCarousel({ quizListData }: QuizCarouselProps) {
   return (
     <div className="w-full">
-      <h3>퀴즈 풀기</h3>
       <Carousel
         previewDatas={quizListData}
         itemComponent={Quiz}


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 로그인여부에 따라 다른 퀴즈 커버 보여주기
- Close #109 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
로그인 여부에 따라 다른 컴포넌트가 보임
리스닝, 리딩 동일한 커버가 보입니다. 
![image](https://github.com/user-attachments/assets/d8701e12-a990-45a9-98bf-c4b5736df937)
![image](https://github.com/user-attachments/assets/d91017e5-d307-41f6-98f6-84ed63403cf5)


### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
![image](https://github.com/user-attachments/assets/01efd35f-6415-48c2-b9f7-dd13cc8e0dc5)
- [ ] 데이터가 없을때는 '퀴즈를 만드는중입니다?' 보여주기??

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
