### PR TITLE
[feat] pathname에 따라 sideBar를 layout에 포함 결정 로직, oauth로그인 리다이렉트 로직

### DIFF
--- a/src/app/(default)/learn/listening/detail/[id]/page.tsx
+++ b/src/app/(default)/learn/listening/detail/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
   useCreateScrap,
   useDeleteScrap,
 } from '@/api/hooks/useScrap';
+import { useParams } from 'next/navigation';
 
 export default function DetailListeningPage() {
   const param = useParams();

--- a/src/app/(default)/learn/listening/detail/[id]/page.tsx
+++ b/src/app/(default)/learn/listening/detail/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
@@ -12,6 +11,7 @@ import { useContentDetail } from '@/api/hooks/useContentDetail';
 import { useUserLoginStatus } from '@/api/hooks/useUserInfo';
 import QuizCarousel from '@/components/quiz/QuizCarousel';
 import { useFetchQuiz } from '@/api/hooks/useQuiz';
+import LogInOutButton from '@/components/LogInOutButton';
 import FloatingButtons from '@/components/FloatingButtons';
 import {
   useCheckScrap,
@@ -32,7 +32,6 @@ export default function DetailListeningPage() {
 
   const { data: isLoginData } = useUserLoginStatus();
   const isLogin = isLoginData?.data; // 로그인 상태 확인
-  const router = useRouter(); // login페이지로 이동
   const [showLoginModal, setShowLoginModal] = useState(false); // 권한 없을때 로그인 모달
 
   const { data: checkScrap } = useCheckScrap(contentId);
@@ -141,12 +140,7 @@ export default function DetailListeningPage() {
             <h2 className="text-3xl font-bold text-center mb-8">
               퀴즈를 풀려면 로그인을 하세요
             </h2>
-            <Button
-              className="bg-white text-purple-600 hover:bg-purple-100 transition-colors duration-200"
-              onClick={() => router.push('/login')}
-            >
-              로그인하기
-            </Button>
+            <LogInOutButton color="bg-white text-purple-500" />
           </div>
         </div>
       )}
@@ -160,13 +154,7 @@ export default function DetailListeningPage() {
           description="이 기능을 이용하려면 로그인이 필요해요! "
         >
           <div className="flex justify-center gap-4 mt-4">
-            <Button
-              variant="default"
-              className="hover:bg-violet-900 w-full"
-              onClick={() => router.push('/login')}
-            >
-              로그인 하러 가기
-            </Button>
+            <LogInOutButton />
           </div>
         </Modal>
       )}

--- a/src/app/(default)/learn/reading/detail/[id]/page.tsx
+++ b/src/app/(default)/learn/reading/detail/[id]/page.tsx
@@ -13,6 +13,7 @@ import QuizCarousel from '@/components/quiz/QuizCarousel';
 import Tooltip from '@/components/Tooltip';
 import MemoInput from '@/components/MemoInput';
 import Modal from '@/components/Modal';
+import LogInOutButton from '@/components/LogInOutButton';
 import { useContentDetail } from '@/api/hooks/useContentDetail';
 import {
   useFetchBookmarksByContendId,
@@ -20,7 +21,7 @@ import {
   useUpdateBookmark,
   useDeleteBookmark,
 } from '@/api/hooks/useBookmarks';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import FloatingButtons from '@/components/FloatingButtons';
 import {
   useCreateScrap,
@@ -38,7 +39,6 @@ export default function DetailReadingPage() {
   // 로그인 권한 훅
   const { data: isLoginData } = useUserLoginStatus();
   const isLogin = isLoginData?.data; // 로그인 상태 확인
-  const router = useRouter(); // login페이지로 이동
   // 로그읜 모달
   const [showLoginModal, setShowLoginModal] = useState(false); // 권한 없을때 로그인 모달
 
@@ -420,12 +420,7 @@ export default function DetailReadingPage() {
                 <h2 className="text-3xl font-bold text-center mb-8">
                   퀴즈를 풀려면 로그인을 하세요
                 </h2>
-                <Button
-                  className="bg-white text-purple-600 hover:bg-purple-100 transition-colors duration-200"
-                  onClick={() => router.push('/login')}
-                >
-                  로그인하기
-                </Button>
+                <LogInOutButton />
               </div>
             </div>
           )}
@@ -474,13 +469,7 @@ export default function DetailReadingPage() {
           description="이 기능을 이용하려면 로그인이 필요해요! "
         >
           <div className="flex justify-center gap-4 mt-4">
-            <Button
-              variant="default"
-              className="hover:bg-violet-900 w-full"
-              onClick={() => router.push('/login')}
-            >
-              로그인 하러 가기
-            </Button>
+            <LogInOutButton />
           </div>
         </Modal>
       )}

--- a/src/app/(default)/scrapbook/layout.tsx
+++ b/src/app/(default)/scrapbook/layout.tsx
@@ -3,8 +3,9 @@
 import { Bookmark, Plus, HighlighterIcon } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useUserLoginStatus } from '@/api/hooks/useUserInfo';
+import LogInOutButton from '@/components/LogInOutButton';
 import DisabledModal from '@/components/DisabledModal';
 
 interface NavItemProps {
@@ -83,7 +84,6 @@ export default function ScrapbookLayout({
   // 로그인 권한 훅
   const { data: isLoginData } = useUserLoginStatus();
   const isLogin = isLoginData?.data; // 로그인 상태 확인
-  const router = useRouter(); // login페이지로 이동
   // 로그읜 모달
   return (
     <>
@@ -101,13 +101,7 @@ export default function ScrapbookLayout({
           description="이 기능을 이용하려면 로그인이 필요해요! "
         >
           <div className="flex justify-center gap-4 mt-4">
-            <Button
-              variant="default"
-              className="hover:bg-violet-900 w-full"
-              onClick={() => router.push('/login')}
-            >
-              로그인 하러 가기
-            </Button>
+            <LogInOutButton />
           </div>
         </DisabledModal>
       )}

--- a/src/app/(fullscreen)/login/page.tsx
+++ b/src/app/(fullscreen)/login/page.tsx
@@ -9,18 +9,21 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { BookOpen, Headphones } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 const BASE_URL = `${process.env.NEXT_PUBLIC_BASE_URL}`;
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
-  // middleware 수정에 따라 동기화 필요
+  // todo : 추후 백엔드 oauth로직과 연결 필요!
   const handleOAuthLogin = (provider: string) => {
     console.log(`Redirecting to ${provider} OAuth login...`);
+    const returnUrl = searchParams.get('returnUrl');
+
     router.push(
-      `${BASE_URL}/oauth2/authorization/${provider}?returnUrl=${encodeURIComponent('/learn/listening')}`,
+      `${BASE_URL}/oauth2/authorization/${provider}${returnUrl ? `?returnUrl=${encodeURIComponent(returnUrl)}` : ''}`,
     );
   };
 

--- a/src/components/LogInOutButton.tsx
+++ b/src/components/LogInOutButton.tsx
@@ -6,7 +6,11 @@ import { useUserLoginStatus } from '@/api/hooks/useUserInfo'; // custom hook imp
 import { useRequestLogout } from '@/api/hooks/useUserInfo'; // custom hook import
 import { usePathname } from 'next/navigation';
 
-export default function LogInOutButton() {
+interface LogInOutButtonProps {
+  color?: string;
+}
+
+export default function LogInOutButton({ color }: LogInOutButtonProps) {
   const { data: isLogin } = useUserLoginStatus();
   const { mutate: fetchUserLogout } = useRequestLogout();
   const currentPathname = usePathname();
@@ -15,7 +19,7 @@ export default function LogInOutButton() {
     <Button onClick={() => fetchUserLogout()}>로그아웃</Button>
   ) : (
     <Link href={`/login?returnUrl=${currentPathname}`}>
-      <Button>로그인</Button>
+      <Button className={color || ''}>로그인</Button>
     </Link>
   );
 }

--- a/src/components/LogInOutButton.tsx
+++ b/src/components/LogInOutButton.tsx
@@ -4,15 +4,17 @@ import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { useUserLoginStatus } from '@/api/hooks/useUserInfo'; // custom hook import
 import { useRequestLogout } from '@/api/hooks/useUserInfo'; // custom hook import
+import { usePathname } from 'next/navigation';
 
 export default function LogInOutButton() {
   const { data: isLogin } = useUserLoginStatus();
   const { mutate: fetchUserLogout } = useRequestLogout();
+  const currentPathname = usePathname();
 
   return isLogin?.data ? (
     <Button onClick={() => fetchUserLogout()}>로그아웃</Button>
   ) : (
-    <Link href="/login">
+    <Link href={`/login?returnUrl=${currentPathname}`}>
       <Button>로그인</Button>
     </Link>
   );

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useRef } from 'react';
 import { HighlighterIcon, MessageCircleMoreIcon, Trash2 } from 'lucide-react';
 import { useUserLoginStatus } from '@/api/hooks/useUserInfo';
-import { useRouter } from 'next/navigation';
+import LogInOutButton from '@/components/LogInOutButton';
 
 type TooltipProps = {
   position: { top: number; left: number };
@@ -25,7 +25,6 @@ export default function Tooltip({
   const tooltipRef = useRef<HTMLDivElement>(null);
   const { data: isLoginData } = useUserLoginStatus();
   const isLogin = isLoginData?.data; // 로그인 상태 확인
-  const router = useRouter(); // 로그인권한 없을 때 북마크, 메모 누르면 login페이지로 이동
 
   // 외부 클릭 감지 및 툴팁 닫기
   useEffect(() => {
@@ -60,16 +59,7 @@ export default function Tooltip({
       {/* 버튼 아이템 */}
       {!isLogin ? (
         <span className="flex items-center px-1">
-          <button
-            type="button"
-            className="p-2 text-gray-600 hover:bg-gray-100 rounded cursor-pointer bg-primary text-white inline-flex items-center"
-            onClick={(e) => {
-              e.stopPropagation();
-              router.push('/login');
-            }}
-          >
-            로그인
-          </button>
+          <LogInOutButton />
           <span className="ml-2 ">
             을 하면 형광펜과 메모를 사용할 수 있어요.
           </span>

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -12,10 +12,10 @@ import {
   useFetchBookmarksByContendId,
 } from '@/api/hooks/useBookmarks';
 import { useUserLoginStatus } from '@/api/hooks/useUserInfo';
-import { useRouter } from 'next/navigation';
 import { Check, X, BookmarkPlus, MessageSquarePlus } from 'lucide-react';
 import { convertTime } from '@/lib/convertTime';
 import { findCurrentSubtitleIndex } from '@/lib/findCurrentSubtitleIndex';
+import LogInOutButton from './LogInOutButton';
 import ControlBar from './ControlBar';
 import SubtitleOption from './SubtitleOption';
 import { ReactScriptPlayer } from './ReactScriptPlayer';
@@ -57,7 +57,6 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
 
   const { data: isLoginData } = useUserLoginStatus();
   const isLogin = isLoginData?.data; // 로그인 상태 확인
-  const router = useRouter(); // login페이지로 이동
   const [showLoginModal, setShowLoginModal] = useState(false); // 권한 없을때 로그인 모달
 
   const [isAddingNote, setIsAddingNote] = useState(false);
@@ -227,13 +226,7 @@ function VideoPlayer({ videoUrl, scriptsData }: VideoPlayerProps) {
           description="이 기능을 이용하려면 로그인이 필요해요! "
         >
           <div className="flex justify-center gap-4 mt-4">
-            <Button
-              variant="default"
-              className="hover:bg-violet-900 w-full"
-              onClick={() => router.push('/login')}
-            >
-              로그인 하러 가기
-            </Button>
+            <LogInOutButton />
           </div>
         </Modal>
       )}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import ReactPlayer from 'react-player';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { Script } from '@/types/ContentDetail';
 import {
   useCreateBookmark,

--- a/src/components/layout/ContentWrapper.tsx
+++ b/src/components/layout/ContentWrapper.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-// import { headers } from 'next/headers';
 import { usePathname } from 'next/navigation';
 
 import SideArea from './SideArea';
@@ -11,14 +10,10 @@ export default function ContentWrapper({
 }: {
   children: React.ReactNode;
 }): JSX.Element {
-  // const header = headers();
-  // const pathname = header.get('x-current-path');
   const pathname = usePathname();
-  console.log(pathname);
 
   return (
     <div className="flex justify-center max-w-[1140px] mx-auto">
-      <p>{pathname}</p>
       <div className="flex-1 py-[60px]">{children}</div>
       {!pathname?.includes('/mypage') && <SideArea />}
     </div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,12 +4,18 @@ import type { NextRequest } from 'next/server';
 export function middleware(request: NextRequest) {
   // 서버컴포넌트에서는 쿠키 접근 가능
   const token = request.cookies.get('access_token');
+  // token없으면 어느 페이지에서든 /login으로 리다이렉트
   if (!token) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
-  return NextResponse.next();
+  return NextResponse.next({ request });
 }
 
 export const config = {
-  matcher: ['/mypage/:path*'],
+  matcher: [
+    '/mypage/:path*',
+    // todo : 추후 아래 코드 추가 필요
+    // match all routes except static files and APIs
+    // '/((?!api|_next/static|_next/image|favicon.ico|favicon.svg|sitemap.xml|robots.txt).*)',
+  ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,10 +12,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    '/mypage/:path*',
-    // todo : 추후 아래 코드 추가 필요
-    // match all routes except static files and APIs
-    // '/((?!api|_next/static|_next/image|favicon.ico|favicon.svg|sitemap.xml|robots.txt).*)',
-  ],
+  matcher: ['/mypage/:path*'],
 };


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : pathname에 따라 sideBar를 layout에 포함 결정 로직, oauth로그인 리다이렉트 로직
- Close #122 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
(커밋 메세지 참고)
1. pathname에 따라 sideBar를 layout에 포함시키는 여부를 결정하는 로직
2. oauth로그인할때, 로그인 버튼 누를 때의 페이지 pathname보내는 로직. 이 로직으로 로그인 완료후 로그인 전 페이지로 되돌아올 수 있습니다.


### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
-  oauth 리다이렉트 로직(2번)은 middleware와는 관련없습니다! 제가 잘못 안 것이었습니다!

### ✅ Checklist
- [ ] 추후 백엔드 redirect url이 구현되면 잘 동작하는지 체킹하기
- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
