### PR TITLE
feat : 마이페이지 로그인 상태가 유지가 안 되는 문제 해결

### DIFF
--- a/src/api/hooks/useUserLoginStatus.ts
+++ b/src/api/hooks/useUserLoginStatus.ts
@@ -3,10 +3,14 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { fetchUserLoginStatus } from '../queries/userQueries';
 
 // 로그인 상태 확인하는 tanstack query훅.
-const useUserLoginStatus = (): UseQueryResult<UserLoginStatusResponse> => {
+const useUserLoginStatus = (
+  initialData?: UserLoginStatusResponse,
+): UseQueryResult<UserLoginStatusResponse> => {
   return useQuery<UserLoginStatusResponse>({
     queryKey: ['loginStatus'],
     queryFn: fetchUserLoginStatus,
+    initialData,
+    refetchOnWindowFocus: true,
   });
 };
 

--- a/src/app/(default)/layout.tsx
+++ b/src/app/(default)/layout.tsx
@@ -6,6 +6,7 @@ import { MobileNav } from '@/components/layout/MobileNav';
 import ContentWrapper from '@/components/layout/ContentWrapper';
 import QueryClientProvider from '@/providers/QueryClientProvider';
 import { Toaster } from '@/components/ui/toaster';
+import { cookies } from 'next/headers';
 
 const pretendard = localFont({
   src: '../fonts/PretendardVariable.woff2',
@@ -22,10 +23,17 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieList = cookies();
+  const isLoggedIn = !!cookieList.get('access_token');
+
   return (
     <html lang="en">
       <body className={`${pretendard.variable} antialiased`}>
-        <QueryClientProvider>
+        <QueryClientProvider
+          initialDatas={[
+            { queryKey: ['loginStatus'], initialData: { data: isLoggedIn } }, // 현재는 로그인상태만 받아서 넘겨줌, 추후 외부 스크랩도 추가 가능
+          ]}
+        >
           <Header />
           <ContentWrapper>{children}</ContentWrapper>
           <Toaster /> {/* shadcn toast사용하기 위한 설정  */}

--- a/src/providers/QueryClientProvider.tsx
+++ b/src/providers/QueryClientProvider.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const queryClientOptions = {
   defaultOptions: {
     queries: {
-      staleTime: 60 * 1000,
+      // staleTime: 60 * 1000, // todo : 이것때문에 자동설정된  refetchOnWindowFocus 작동안하는 이슈로 추측됨
     },
   },
 };
@@ -25,12 +25,20 @@ function getQueryClient() {
   return browserQueryClient;
 }
 
+interface TanstackQueryPoviderProps {
+  children: React.ReactNode;
+  initialDatas?: { queryKey: string[]; initialData: unknown }[];
+}
+
 export default function TanstackQueryPovider({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+  initialDatas,
+}: TanstackQueryPoviderProps) {
   const queryClient = getQueryClient();
+
+  initialDatas?.forEach(({ queryKey, initialData }) => {
+    queryClient.setQueryData(queryKey, initialData);
+  });
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 마이페이지 로그인 상태가 유지가 안 되는 문제 해결
- Close #141 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- next/headers 모듈의 cookies를 사용해 서버에서 access_token 쿠키를 가져옵니다.
- isLoggedIn 변수는 쿠키에 access_token이 존재하는지 여부에 따라 true, false가 됩니다. 
- 간단한 next auth를 구현했습니다.
- initialDatas 라는 속성을 사용해, loginStatus에 초기 데이터로 isLoggedIn 값을 설정합니다. 
   - 페이지 로딩 시 바로 로그인 상태를 알 수 있습니다.
- 이제 로그인한 상태에서 마이페이지에서 새로고침을 했을 때 로그인 상태가 유지가 안 되는 문제가 해결됩니다.

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
