### PR TITLE
feat : 페이지네이션 컴포넌트 구현

### DIFF
--- a/src/api/hooks/usePreview.ts
+++ b/src/api/hooks/usePreview.ts
@@ -26,16 +26,26 @@ export const useListeningPreview =
     });
   };
 
-export const useReadingContents = (): UseQueryResult<ContentsResponse> => {
+export const useReadingContents = (
+  page = 0,
+  size = 5,
+  sort = 'createdAt',
+  direction = 'DESC',
+): UseQueryResult<ContentsResponse> => {
   return useQuery({
-    queryKey: ['readingContentsData'],
-    queryFn: () => fetchReadingContents(),
+    queryKey: ['readingContentsData', page, size, sort, direction],
+    queryFn: () => fetchReadingContents(page, size, sort, direction),
   });
 };
 
-export const useListeningContents = (): UseQueryResult<ContentsResponse> => {
+export const useListeningContents = (
+  page = 0,
+  size = 5,
+  sort = 'createdAt',
+  direction = 'DESC',
+): UseQueryResult<ContentsResponse> => {
   return useQuery({
-    queryKey: ['listeningContentsData'],
-    queryFn: () => fetchListeningContents(),
+    queryKey: ['listeningContentsData', page, size, sort, direction],
+    queryFn: () => fetchListeningContents(page, size, sort, direction),
   });
 };

--- a/src/api/queries/contentsQueries.ts
+++ b/src/api/queries/contentsQueries.ts
@@ -59,15 +59,22 @@ export const fetchContentDetail = async (
   return response.json();
 };
 
-// TODO(@smosco):query param으로 정렬, 카테고리, 사이즈 조절 넘기기
-export const fetchReadingContents = async (): Promise<ContentsResponse> => {
-  const response = await fetch(`${BASE_URL}/view/reading`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
+export const fetchReadingContents = async (
+  page = 0,
+  size = 5,
+  sort = 'createdAt',
+  direction = 'DESC',
+): Promise<ContentsResponse> => {
+  const response = await fetch(
+    `${BASE_URL}/view/reading?sort=${sort}&direction=${direction}&page=${page}&size=${size}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
     },
-    credentials: 'include',
-  });
+  );
 
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
@@ -76,14 +83,22 @@ export const fetchReadingContents = async (): Promise<ContentsResponse> => {
   return response.json();
 };
 
-export const fetchListeningContents = async (): Promise<ContentsResponse> => {
-  const response = await fetch(`${BASE_URL}/view/listening`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
+export const fetchListeningContents = async (
+  page = 0,
+  size = 5,
+  sort = 'createdAt',
+  direction = 'DESC',
+): Promise<ContentsResponse> => {
+  const response = await fetch(
+    `${BASE_URL}/view/listening?sort=${sort}&direction=${direction}&page=${page}&size=${size}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
     },
-    credentials: 'include',
-  });
+  );
 
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/app/(default)/learn/listening/page.tsx
+++ b/src/app/(default)/learn/listening/page.tsx
@@ -5,14 +5,21 @@ import { useListeningContents } from '@/api/hooks/usePreview';
 import ContentTypeFilter from '@/components/ContentTypeFilter';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import EmptyAlert from '@/components/EmptyAlert';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Pagination from '@/components/Pagination';
 
 function ListeningPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentPage = Number(searchParams.get('page') || 0);
+
   const {
     data: listeningContents,
     isLoading,
     isError,
     error,
-  } = useListeningContents();
+  } = useListeningContents(currentPage - 1);
 
   if (isLoading) {
     return <LoadingSpinner />;
@@ -26,6 +33,10 @@ function ListeningPage() {
     return <EmptyAlert alertDescription="북마크가 없습니다." />;
   }
 
+  const handlePageChange = (page: number) => {
+    router.push(`?page=${page}`);
+  };
+
   return (
     <main>
       <ContentTypeFilter />
@@ -34,6 +45,10 @@ function ListeningPage() {
           <ListeningPreviewCard key={content.contentId} data={content} />
         ))}
       </div>
+      <Pagination
+        totalPages={listeningContents.data.totalPages}
+        onPageChange={handlePageChange}
+      />
     </main>
   );
 }

--- a/src/app/(default)/learn/reading/page.tsx
+++ b/src/app/(default)/learn/reading/page.tsx
@@ -4,14 +4,22 @@ import LoadingSpinner from '@/components/LoadingSpinner';
 import ArticlePreview from '@/components/ArticlePreview';
 import { useReadingContents } from '@/api/hooks/usePreview';
 import ContentTypeFilter from '@/components/ContentTypeFilter';
+import Pagination from '@/components/Pagination';
+import { useSearchParams, useRouter } from 'next/navigation';
 
 export default function ReadingPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentPage = Number(searchParams.get('page') || 0);
+
   const {
     data: readingContents,
     isLoading,
     isError,
     error,
-  } = useReadingContents();
+    // TODO(@smosco): 백엔드에 page 1부터 시작하게 변경 요청
+  } = useReadingContents(currentPage - 1);
 
   if (isLoading) {
     return <LoadingSpinner />;
@@ -25,6 +33,10 @@ export default function ReadingPage() {
     return <p>콘텐츠가 없습니다.</p>;
   }
 
+  const handlePageChange = (page: number) => {
+    router.push(`?page=${page}`);
+  };
+
   return (
     <div>
       <ContentTypeFilter />
@@ -33,6 +45,10 @@ export default function ReadingPage() {
           <ArticlePreview key={content.contentId} data={content} />
         ))}
       </ul>
+      <Pagination
+        totalPages={readingContents.data.totalPages}
+        onPageChange={handlePageChange}
+      />
     </div>
   );
 }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({
+  totalPages,
+  onPageChange,
+}: PaginationProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const pageRange = 10;
+  const startPage = Math.floor((currentPage - 1) / pageRange) * pageRange + 1;
+  const endPage = Math.min(startPage + pageRange - 1, totalPages);
+
+  const handlePageClick = (page: number) => {
+    setCurrentPage(page);
+    onPageChange(page);
+  };
+
+  const handlePrevClick = () => {
+    if (currentPage > 1) {
+      handlePageClick(startPage - 1);
+    }
+  };
+
+  const handleNextClick = () => {
+    if (currentPage < totalPages) {
+      handlePageClick(endPage + 1);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center space-x-2 pb-28 pt-12">
+      {startPage > 1 && (
+        <button
+          type="button"
+          onClick={handlePrevClick}
+          className="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-200"
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="w-5 h-5" color="gray" />
+        </button>
+      )}
+      {Array.from(
+        // 길이가 endPage - startPage + 1 인 배열 생성
+        { length: endPage - startPage + 1 },
+        // 배열의 요소는 startPage 에 index 를 더한 값을 가짐
+        (_, index) => startPage + index,
+      ).map((page) => (
+        <button
+          type="button"
+          key={page}
+          onClick={() => handlePageClick(page)}
+          className={`w-10 h-10 flex items-center justify-center rounded-lg ${
+            currentPage === page
+              ? 'bg-purple-50 text-purple-600'
+              : 'text-gray-600 hover:bg-gray-50'
+          }`}
+        >
+          {page}
+        </button>
+      ))}
+      {endPage < totalPages && (
+        <button
+          type="button"
+          onClick={handleNextClick}
+          className="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-gray-200"
+          aria-label="Next page"
+        >
+          <ChevronRight className="w-5 h-5" color="gray" />
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 페이지네이션 컴포넌트를 구현하고 리딩 리스닝 목록 페이지에 페이지네이션을 적용했습니다.
- Close #144 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- 리딩 리스닝 콘텐츠를 fetch 하는 쿼리 함수 api 요청 url에 sort, direction, page, size 추가했습니다.
  - 현재 한 페이지에 5개 받아오는 걸 기본으로 설정 했습니다.
- 페이지네이션 컴포넌트를 구현했습니다. 어디에서든 가져다 사용하면 됩니다.
- 리딩 리스닝 목록 불러오기 페이지에서 useSearchParams로 페이지 번호 가져오고 페이지네이션 컴포넌트의 버튼 클릭하면 router.push로 https://local.biengual.store:3000/learn/reading?page=2 이런 식으로 경로를 이동시킵니다.

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/f81ed5eb-e85a-4d47-957a-c95974c0dfc0)

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->
- 스크랩이랑 북마크 메모에도 페이지네이션 추가하고 싶었는데 아직 api가 없어서 추가하지 않았습니다. 

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
